### PR TITLE
fix: correct source configuration typo and query polling setting names

### DIFF
--- a/modules/ROOT/examples/docker-data/source.query.avro.json
+++ b/modules/ROOT/examples/docker-data/source.query.avro.json
@@ -15,7 +15,7 @@
     "neo4j.query": "MATCH (ts:TestSource) WHERE ts.timestamp > $lastCheck RETURN ts.name AS name, ts.surname AS surname, ts.timestamp AS timestamp",
     "neo4j.query.streaming-property": "timestamp",
     "neo4j.query.topic": "test-source",
-    "neo4j.query.polling-interval": "1s",
-    "neo4j.query.polling-duration": "5s"
+    "neo4j.query.poll-interval": "1s",
+    "neo4j.query.poll-duration": "5s"
   }
 }

--- a/modules/ROOT/examples/docker-data/source.query.json-schema.json
+++ b/modules/ROOT/examples/docker-data/source.query.json-schema.json
@@ -15,7 +15,7 @@
     "neo4j.query": "MATCH (ts:TestSource) WHERE ts.timestamp > $lastCheck RETURN ts.name AS name, ts.surname AS surname, ts.timestamp AS timestamp",
     "neo4j.query.streaming-property": "timestamp",
     "neo4j.query.topic": "test-source",
-    "neo4j.query.polling-interval": "1s",
-    "neo4j.query.polling-duration": "5s"
+    "neo4j.query.poll-interval": "1s",
+    "neo4j.query.poll-duration": "5s"
   }
 }

--- a/modules/ROOT/examples/docker-data/source.query.json-string.json
+++ b/modules/ROOT/examples/docker-data/source.query.json-string.json
@@ -15,7 +15,7 @@
     "neo4j.query": "MATCH (ts:TestSource) WHERE ts.timestamp > $lastCheck RETURN ts.name AS name, ts.surname AS surname, ts.timestamp AS timestamp",
     "neo4j.query.streaming-property": "timestamp",
     "neo4j.query.topic": "test-source",
-    "neo4j.query.polling-interval": "1s",
-    "neo4j.query.polling-duration": "5s"
+    "neo4j.query.poll-interval": "1s",
+    "neo4j.query.poll-duration": "5s"
   }
 }

--- a/modules/ROOT/examples/docker-data/source.query.json.json
+++ b/modules/ROOT/examples/docker-data/source.query.json.json
@@ -17,7 +17,7 @@
     "neo4j.query": "MATCH (ts:TestSource) WHERE ts.timestamp > $lastCheck RETURN ts.name AS name, ts.surname AS surname, ts.timestamp AS timestamp",
     "neo4j.query.streaming-property": "timestamp",
     "neo4j.query.topic": "test-source",
-    "neo4j.query.polling-interval": "1s",
-    "neo4j.query.polling-duration": "5s"
+    "neo4j.query.poll-interval": "1s",
+    "neo4j.query.poll-duration": "5s"
   }
 }

--- a/modules/ROOT/examples/docker-data/source.query.protobuf.json
+++ b/modules/ROOT/examples/docker-data/source.query.protobuf.json
@@ -19,7 +19,7 @@
     "neo4j.query": "MATCH (ts:TestSource) WHERE ts.timestamp > $lastCheck RETURN ts.name AS name, ts.surname AS surname, ts.timestamp AS timestamp",
     "neo4j.query.streaming-property": "timestamp",
     "neo4j.query.topic": "test-source",
-    "neo4j.query.polling-interval": "1s",
-    "neo4j.query.polling-duration": "5s"
+    "neo4j.query.poll-interval": "1s",
+    "neo4j.query.poll-duration": "5s"
   }
 }

--- a/modules/ROOT/pages/source/configuration.adoc
+++ b/modules/ROOT/pages/source/configuration.adoc
@@ -52,7 +52,7 @@ Default: `EXTENDED`. label:new[Introduced in 5.1.5]
 | Serialisation strategy for CDC topic key.
 One of `SKIP`, `ELEMENT_ID`, `ENTITY_KEYS`, `WHOLE_VALUE`.
 
-Default: `WHOLE_WALUE`
+Default: `WHOLE_VALUE`
 
 | neo4j.cdc.topic.\{NAME}.value-strategy
 | Serialisation strategy for CDC topic key.


### PR DESCRIPTION
## Issue
The source configuration page lists `WHOLE_WALUE` as the default key strategy, and the source query examples use `neo4j.query.polling-interval`/`polling-duration` which do not match the connector's actual setting names.

## Fix
Correct the default to `WHOLE_VALUE` and rename the example settings to `neo4j.query.poll-interval`/`poll-duration` to match the connector source.