### PR TITLE
doc: update changelog for version 5.5.0 with exactly-once

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,5 +1,5 @@
 name: kafka
-version: '5.4'
+version: '5.5'
 title: Neo4j Connector for Kafka
 start_page: ROOT:index.adoc
 nav:
@@ -11,8 +11,8 @@ asciidoc:
     copyright: Neo4j Inc.
     page-product: Neo4j Connector for Kafka
     confluent-connect-version: '7.7'
-    connector-version: '5.4'
-    exact-connector-version: '5.4.1'
+    connector-version: '5.5'
+    exact-connector-version: '5.5.0'
     kafka-connect-version: '3.7.0'
     page-pagination: true
     product-name: Neo4j Connector for Kafka

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -13,7 +13,7 @@ label:feature[]
 label:new[]
 
 Cypher sink strategy now supports Exactly Once semantics and batched processing.
-| The Cypher sink strategy has been re-implemented on top of the shared sink action abstraction, so it now supports Exactly Once offset tracking and benefits from the batched processing strategies (APOC Core and native) introduced for CDC sink handlers.
+| The Cypher sink strategy has been re-implemented on top of the shared sink action abstraction, so it now supports Exactly Once offset tracking and benefits from the batched processing strategies (APOC Core and native) previously introduced for CDC sink handlers.
 |===
 
 == Version 5.4.0

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -2,6 +2,20 @@
 
 This page lists changes to the {product-name}.
 
+== Version 5.4.2
+
+[cols="1,2",options="header"]
+|===
+| Feature | Details
+
+a|
+label:feature[]
+label:new[]
+
+Cypher sink strategy now supports Exactly Once semantics and batched processing.
+| The Cypher sink strategy has been re-implemented on top of the shared sink action abstraction, so it now supports Exactly Once offset tracking and benefits from the batched processing strategies (APOC Core and native) introduced for CDC sink handlers.
+|===
+
 == Version 5.4.0
 
 [cols="1,2",options="header"]

--- a/modules/ROOT/pages/changelog.adoc
+++ b/modules/ROOT/pages/changelog.adoc
@@ -2,7 +2,7 @@
 
 This page lists changes to the {product-name}.
 
-== Version 5.4.2
+== Version 5.5.0
 
 [cols="1,2",options="header"]
 |===

--- a/modules/ROOT/pages/sink/configuration.adoc
+++ b/modules/ROOT/pages/sink/configuration.adoc
@@ -36,11 +36,6 @@ This setting is ignored when the APOC Core based batching strategy is used.
 | Label name to attach to the node representing the offset of the last successfully processed message.
 When specified, this setting allows to achieve exactly-once processing guarantees for sink strategies by keeping track of the last successfully processed message offset in the database.
 
-[NOTE]
-====
-This setting is applicable to the CDC, CUD, pattern, and Cypher sink strategies.
-====
-
 |===
 
 [[cypher_strategy_settings]]

--- a/modules/ROOT/pages/sink/configuration.adoc
+++ b/modules/ROOT/pages/sink/configuration.adoc
@@ -29,7 +29,7 @@ Default: `50`
 
 [NOTE]
 ====
-This setting is only applicable to CDC sink strategies for the time being, and is ignored for non-CDC strategies and when APOC Core based batching strategy is used.
+This setting is applicable to the CDC, CUD, pattern, and Cypher sink strategies, and is ignored when the APOC Core based batching strategy is used.
 ====
 
 | `neo4j.eos-offset-label` label:new[5.3.0]
@@ -38,7 +38,7 @@ When specified, this setting allows to achieve exactly-once processing guarantee
 
 [NOTE]
 ====
-This setting is only applicable to CDC sink strategies for the time being, and is ignored for non-CDC strategies.
+This setting is applicable to the CDC, CUD, pattern, and Cypher sink strategies.
 ====
 
 |===

--- a/modules/ROOT/pages/sink/configuration.adoc
+++ b/modules/ROOT/pages/sink/configuration.adoc
@@ -29,7 +29,7 @@ Default: `50`
 
 [NOTE]
 ====
-This setting is applicable to the CDC, CUD, pattern, and Cypher sink strategies, and is ignored when the APOC Core based batching strategy is used.
+This setting is ignored when the APOC Core based batching strategy is used.
 ====
 
 | `neo4j.eos-offset-label` label:new[5.3.0]

--- a/modules/ROOT/pages/sink/cypher.adoc
+++ b/modules/ROOT/pages/sink/cypher.adoc
@@ -97,18 +97,13 @@ where `$events` is a batch of change events.
 
 == Batching of Cypher events
 
-Starting from version 5.4.2, batched sink handlers are available for the Cypher strategy to provide better throughput when processing messages.
-These handlers process messages in batches and apply them to the database more efficiently.
+Starting from version 5.4.2, the Cypher strategy processes messages in batches for better throughput.
+The configured Cypher statement is applied once per message, but the connector executes a whole batch together:
 
-There are currently two batching strategies used by the Cypher sink handlers:
+* When APOC Core is available, batches run via the `apoc.cypher.doIt` procedure.
+* Otherwise, the connector falls back to combining up to `neo4j.max-batched-queries` messages (default `50`) into a single query using subqueries.
 
-. APOC Core strategy: This strategy uses the `apoc.cypher.doIt` procedure to execute batches of the configured Cypher statement, one invocation per message in the batch.
-. Native strategy: This strategy generates a single Cypher statement containing multiple subqueries for each message in the batch, and executes it using the standard Cypher execution engine.
-The maximum number of subqueries included in a single batch when using the native strategy can be configured using the `neo4j.max-batched-queries` setting, which defaults to `50`.
-
-The connector defaults to the APOC Core batching strategy when available, falling back to the native strategy when APOC Core is not available on the target database.
-
-Batch size, which applies to both batching strategies, can be configured using the `neo4j.batch-size` setting, which defaults to `1000`.
+Batch size can be configured using the `neo4j.batch-size` setting, which defaults to `1000`.
 
 == Exactly-once semantics
 

--- a/modules/ROOT/pages/sink/cypher.adoc
+++ b/modules/ROOT/pages/sink/cypher.adoc
@@ -97,11 +97,10 @@ where `$events` is a batch of change events.
 
 == Batching of Cypher events
 
-Starting from version 5.4.2, the Cypher strategy processes messages in batches for better throughput.
-The configured Cypher statement is applied once per message, but the connector executes a whole batch together:
+The Cypher strategy processes messages in batches for better throughput.
 
 * When APOC Core is available, batches run via the `apoc.cypher.doIt` procedure.
-* Otherwise, the connector falls back to combining up to `neo4j.max-batched-queries` messages (default `50`) into a single query using subqueries.
+* Otherwise, the connector embeds the provided statement into a subquery and executes the batch with this generated statement.
 
 Batch size can be configured using the `neo4j.batch-size` setting, which defaults to `1000`.
 

--- a/modules/ROOT/pages/sink/cypher.adoc
+++ b/modules/ROOT/pages/sink/cypher.adoc
@@ -94,3 +94,38 @@ MERGE (p)-[:BELONGS_TO]->(f)
 
 where `$events` is a batch of change events.
 ====
+
+== Batching of Cypher events
+
+Starting from version 5.4.2, batched sink handlers are available for the Cypher strategy to provide better throughput when processing messages.
+These handlers process messages in batches and apply them to the database more efficiently.
+
+There are currently two batching strategies used by the Cypher sink handlers:
+
+. APOC Core strategy: This strategy uses the `apoc.cypher.doIt` procedure to execute batches of the configured Cypher statement, one invocation per message in the batch.
+. Native strategy: This strategy generates a single Cypher statement containing multiple subqueries for each message in the batch, and executes it using the standard Cypher execution engine.
+The maximum number of subqueries included in a single batch when using the native strategy can be configured using the `neo4j.max-batched-queries` setting, which defaults to `50`.
+
+The connector defaults to the APOC Core batching strategy when available, falling back to the native strategy when APOC Core is not available on the target database.
+
+Batch size, which applies to both batching strategies, can be configured using the `neo4j.batch-size` setting, which defaults to `1000`.
+
+== Exactly-once semantics
+
+Starting from version 5.4.2, the Cypher sink handler can be configured to achieve exactly-once processing guarantees by keeping track of the last successfully processed message offset in the database.
+This is achieved by storing a dedicated node representing the offset of the last successfully processed message.
+
+Use the `neo4j.eos-offset-label` setting to specify a label name to attach to the offset node.
+This setting is empty by default, meaning that exactly-once semantics are disabled and the connector will not keep track of processed message offsets in the target database, meaning that at-least-once processing guarantees are provided.
+
+[IMPORTANT]
+====
+Make sure that the configured label has a node key constraint defined on the `strategy`, `topic` and `partition` node properties.
+
+For example, if your `neo4j.eos-offset-label` is set to `__KafkaOffset`, the following constraint must appear on the target database:
+
+[source,cypher]
+----
+CREATE CONSTRAINT kafka_offset_key IF NOT EXISTS FOR (n:__KafkaOffset) REQUIRE (n.strategy, n.topic, n.partition) IS NODE KEY
+----
+====

--- a/modules/ROOT/pages/sink/cypher.adoc
+++ b/modules/ROOT/pages/sink/cypher.adoc
@@ -106,7 +106,7 @@ Batch size can be configured using the `neo4j.batch-size` setting, which default
 
 == Exactly-once semantics
 
-Starting from version 5.4.2, the Cypher sink handler can be configured to achieve exactly-once processing guarantees by keeping track of the last successfully processed message offset in the database.
+Starting from version 5.5.0, the Cypher sink handler can be configured to achieve exactly-once processing guarantees by keeping track of the last successfully processed message offset in the database.
 This is achieved by storing a dedicated node representing the offset of the last successfully processed message.
 
 Use the `neo4j.eos-offset-label` setting to specify a label name to attach to the offset node.

--- a/modules/ROOT/pages/source/query.adoc
+++ b/modules/ROOT/pages/source/query.adoc
@@ -128,7 +128,7 @@ Although the generated message will look exactly the same as the `COMPACT` mode,
 
 == Exactly Once Semantics
 
-The query strategy declares itself as *not* Exactly Once capable, and provides at-least-once delivery guarantees.
+The query strategy is *not* Exactly Once capable, and provides at-least-once delivery guarantees.
 Because messages are derived from a user-provided Cypher query rather than from the transaction log, the connector cannot guarantee that each record is delivered exactly once across connector restarts or failures, so duplicate records are possible.
 
 If you require exactly-once delivery on the source side, use the xref:source/cdc.adoc[CDC source strategy] instead, which declares itself Exactly Once capable on Kafka Connect clusters that support link:https://cwiki.apache.org/confluence/display/KAFKA/KIP-618%3A+Exactly-Once+Support+for+Source+Connectors[KIP-618].

--- a/modules/ROOT/pages/source/query.adoc
+++ b/modules/ROOT/pages/source/query.adoc
@@ -126,11 +126,11 @@ include::example$producer-data/query.compact.json[]
 In case you generate complex data structures as part of your Cypher query, you can also use the `RAW_JSON_STRING` payload mode which will produce a raw JSON string representation of the data without any schema compatibility guarantees.
 Although the generated message will look exactly the same as the `COMPACT` mode, it will be encoded as a `STRING` type.
 
-== Exactly Once Semantics
+== Exactly-once semantics
 
-The query strategy is *not* Exactly Once capable, and provides at-least-once delivery guarantees.
+The query strategy is *not* exactly-once capable, and provides at-least-once delivery guarantees.
 Because messages are derived from a user-provided Cypher query rather than from the transaction log, the connector cannot guarantee that each record is delivered exactly once across connector restarts or failures, so duplicate records are possible.
 
-If you require exactly-once delivery on the source side, use the xref:source/cdc.adoc[CDC source strategy] instead, which declares itself Exactly Once capable on Kafka Connect clusters that support link:https://cwiki.apache.org/confluence/display/KAFKA/KIP-618%3A+Exactly-Once+Support+for+Source+Connectors[KIP-618].
+If you require exactly-once delivery on the source side, use the xref:source/cdc.adoc[CDC source strategy] instead, which declares itself exactly-once capable on Kafka Connect clusters that support link:https://cwiki.apache.org/confluence/display/KAFKA/KIP-618%3A+Exactly-Once+Support+for+Source+Connectors[KIP-618].
 
 Refer to the xref:source/payload-mode.adoc[payload mode] page for more information about the `neo4j.payload-mode` setting, including its limitations.

--- a/modules/ROOT/pages/source/query.adoc
+++ b/modules/ROOT/pages/source/query.adoc
@@ -126,4 +126,11 @@ include::example$producer-data/query.compact.json[]
 In case you generate complex data structures as part of your Cypher query, you can also use the `RAW_JSON_STRING` payload mode which will produce a raw JSON string representation of the data without any schema compatibility guarantees.
 Although the generated message will look exactly the same as the `COMPACT` mode, it will be encoded as a `STRING` type.
 
+== Exactly Once Semantics
+
+The query strategy declares itself as *not* Exactly Once capable, and provides at-least-once delivery guarantees.
+Because messages are derived from a user-provided Cypher query rather than from the transaction log, the connector cannot guarantee that each record is delivered exactly once across connector restarts or failures, so duplicate records are possible.
+
+If you require exactly-once delivery on the source side, use the xref:source/cdc.adoc[CDC source strategy] instead, which declares itself Exactly Once capable on Kafka Connect clusters that support link:https://cwiki.apache.org/confluence/display/KAFKA/KIP-618%3A+Exactly-Once+Support+for+Source+Connectors[KIP-618].
+
 Refer to the xref:source/payload-mode.adoc[payload mode] page for more information about the `neo4j.payload-mode` setting, including its limitations.

--- a/publish.yml
+++ b/publish.yml
@@ -7,7 +7,7 @@ site:
 content:
   sources:
   - url: ./
-    branches: ['5.0', '5.1', '5.2', '5.3', 'HEAD']
+    branches: ['5.0', '5.1', '5.2', '5.3', '5.4', 'HEAD']
     exclude:
     - '!**/_includes/*'
     - '!**/readme.adoc'
@@ -38,7 +38,7 @@ asciidoc:
     page-search-site: Reference Docs
     page-canonical-root: /docs
     page-pagination: true
-    page-no-canonical: true 
+    page-no-canonical: true
     page-origin-private: true
     page-hide-toc: false
     page-mixpanel: 4bfb2414ab973c741b6f067bf06d5575


### PR DESCRIPTION
 Changes                                                                                                                                                                                                
   - Documented Cypher batching + exactly-once                                                                           
   - Corrected stale "only CDC" notes on eos-offset-label and max-batched-queries (sink/configuration.adoc)                                                                                               
   - Documented that the query source strategy is not EOS-capable (source/query.adoc)                                                                                                                     
   - Added 5.5.0 changelog entry  