### PR TITLE
fix: package name

### DIFF
--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -12,17 +12,17 @@ The latest version of the connector is {exact-connector-version}.
 This package can be deployed to Confluent Platform as a self-managed connector, and to Confluent Cloud as a custom connector to use Aura/Neo4j as a source.
 For sinking data to Aura/Neo4j, please refer to link:{url-confluent-managed-sink-docs}[Neo4j Sink Connector for Confluent Cloud].
 
-The package is available for download from link:{url-confluent-hub-neo4j}[Confluent Hub] or from the link:{url-github}/releases/download/{exact-connector-version}/neo4j-kafka-connect-{exact-connector-version}.zip[GitHub repository].
+The package is available for download from link:{url-confluent-hub-neo4j}[Confluent Hub] or from the link:{url-github}/releases/download/{exact-connector-version}/neo4j-kafka-connect-neo4j-{exact-connector-version}.zip[GitHub repository].
 
 [#kafka-dist]
 === Neo4j Connector for Apache Kafka
 
 This package can be deployed to any Apache Kafka distribution running Apache Kafka Connect, including Amazon Managed Streaming for Apache Kafka (Amazon MSK).
 
-The package is available for download from the link:{url-github}/releases/download/{exact-connector-version}/neo4j-kafka-connect-{exact-connector-version}.jar[GitHub repository].
+The package is available for download from the link:{url-github}/releases/download/{exact-connector-version}/neo4j-kafka-connect-neo4j-{exact-connector-version}.jar[GitHub repository].
 
 == Installation
 
 The {product-name} is a plugin designed to run in an Apache Kafka Connect environment, which is deployed separately from the Neo4j database.
 
-For standalone Kafka Connect installations, download the link:{url-github}/releases/download/{exact-connector-version}/neo4j-kafka-connect-{exact-connector-version}.jar[self-contained JAR file] and copy it into the `plugins` directory for each of your Kafka Connect cluster members.
+For standalone Kafka Connect installations, download the link:{url-github}/releases/download/{exact-connector-version}/neo4j-kafka-connect-neo4j-{exact-connector-version}.jar[self-contained JAR file] and copy it into the `plugins` directory for each of your Kafka Connect cluster members.

--- a/modules/ROOT/pages/quickstart-docker.adoc
+++ b/modules/ROOT/pages/quickstart-docker.adoc
@@ -44,7 +44,7 @@ The directory structure should look like;
 ----
 quickstart/
 ├─ plugins/
-│  ├─ neo4j-kafka-connect-{exact-connector-version}.jar
+│  ├─ neo4j-kafka-connect-neo4j-{exact-connector-version}.jar
 ├─ docker-compose.yml
 
 ----


### PR DESCRIPTION

## Issue
Changes in the Confluent package validation mean we have changed the artifact name: https://github.com/neo4j/neo4j-kafka-connector/pull/629.