### PR TITLE
docs: swatting various bugs

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -32,6 +32,7 @@
 * xref:sink/error-handling.adoc[Error handling]
 * xref:sink/configuration.adoc[Settings]
 * xref:sink/monitoring.adoc[Monitoring]
+* xref:sink/best-practices.adoc[Best practices]
 
 * *Upgrades and migrations*
 * xref:migration/5.1/index.adoc[From 5.0 to 5.1+]

--- a/modules/ROOT/pages/sink.adoc
+++ b/modules/ROOT/pages/sink.adoc
@@ -16,4 +16,4 @@ Use a Cypher-like pattern syntax to transform incoming Kafka messages into Cyphe
 xref:sink/cud.adoc[Create Update Delete (CUD) File]::
 Transform incoming CUD-formatted messages into Cypher write queries.
 
-Not sure which one fits your use case? See xref:sink/best-practices.adoc#choosing-a-strategy[Choosing a sink strategy].
+See xref:sink/best-practices.adoc#choosing-a-strategy[Choosing a sink strategy] for advice on choosing the best strategy for your use case.

--- a/modules/ROOT/pages/sink.adoc
+++ b/modules/ROOT/pages/sink.adoc
@@ -15,3 +15,5 @@ xref:sink/pattern.adoc[Pattern]::
 Use a Cypher-like pattern syntax to transform incoming Kafka messages into Cypher write queries.
 xref:sink/cud.adoc[Create Update Delete (CUD) File]::
 Transform incoming CUD-formatted messages into Cypher write queries.
+
+Not sure which one fits your use case? See xref:sink/best-practices.adoc#choosing-a-strategy[Choosing a sink strategy].

--- a/modules/ROOT/pages/sink/best-practices.adoc
+++ b/modules/ROOT/pages/sink/best-practices.adoc
@@ -1,0 +1,38 @@
+= Best practices for Sink connector
+
+This page collects recommendations and operational practices for running the Sink connector.
+Each recommendation explains the trade-offs so you can decide whether it applies to your use case.
+
+[#choosing-a-strategy]
+== Choosing a sink strategy
+
+The Sink connector supports four strategies for turning incoming Kafka messages into writes to Neo4j: xref:sink/cdc.adoc[Change Data Capture], xref:sink/pattern.adoc[Pattern], xref:sink/cud.adoc[CUD], and xref:sink/cypher.adoc[Cypher].
+Use the following decision guide to pick between them.
+
+[%width="100%",cols="1,2a",opts=header]
+|===
+| Strategy
+| Use it when
+
+| xref:sink/cdc.adoc[Change Data Capture]
+| The messages are produced by a Neo4j xref:source/cdc.adoc[Source connector] configured with the CDC strategy, or by the deprecated link:{page-canonical-root}/kafka-streams[Neo4j Streams] plugin.
+This is the strategy to reach for when you're replicating one Neo4j database into another and don't control the message format yourself, since it's generated for you.
+
+| xref:sink/pattern.adoc[Pattern]
+| The messages come from an arbitrary producer, but each topic's messages consistently map to one node or relationship shape.
+A declarative Cypher-like pattern is enough to extract that shape, without writing any Cypher yourself.
+This is a good default for straightforward event-to-graph mappings.
+
+| xref:sink/cud.adoc[CUD]
+| The messages come from an arbitrary producer that can emit explicit `create`/`update`/`merge`/`delete` JSON commands, or you need more than one operation type multiplexed onto the same topic.
+Prefer this over Pattern when a single topic needs to express more than one kind of write.
+
+| xref:sink/cypher.adoc[Cypher]
+| The write logic doesn't fit the conventions of the other three strategies, for example conditional logic, multiple entities per message with custom relationships between them, or aggregation across message fields.
+This is the escape hatch: full control over the write, at the cost of writing and maintaining the Cypher yourself.
+|===
+
+[TIP]
+====
+Start with Pattern or CUD if your message format is flexible. Reach for Cypher only once you hit something those two conventions can't express, rather than starting there by default.
+====

--- a/modules/ROOT/pages/sink/cdc.adoc
+++ b/modules/ROOT/pages/sink/cdc.adoc
@@ -16,6 +16,13 @@ Two sub-strategies are available:
 
 The `Schema` strategy merges nodes and relationships using the constraints declared in the change event, thus preserving the source schema structure.
 
+[IMPORTANT]
+====
+The change event only carries the *names* of the key properties used by the constraint on the source database, not the constraint itself.
+The Sink connector uses these key properties to build its `MERGE` statements regardless of whether an equivalent constraint exists on the target database. If one is missing, writes still succeed, but without the uniqueness guarantee and index-backed lookups that a matching constraint would provide.
+Make sure the corresponding node key, relationship key, or property uniqueness/existence constraints are created on the *target* database before running this strategy in production.
+====
+
 Configuration of this strategy requires declaration of list of topics to read change events from.
 
 [source,json,subs="verbatim,attributes"]

--- a/modules/ROOT/pages/sink/cdc.adoc
+++ b/modules/ROOT/pages/sink/cdc.adoc
@@ -18,8 +18,10 @@ The `Schema` strategy merges nodes and relationships using the constraints decla
 
 [IMPORTANT]
 ====
-The change event only carries the *names* of the key properties used by the constraint on the source database, not the constraint itself.
-The Sink connector uses these key properties to build its `MERGE` statements regardless of whether an equivalent constraint exists on the target database. If one is missing, writes still succeed, but without the uniqueness guarantee and index-backed lookups that a matching constraint would provide.
+The change event only carries the _names_ of the key properties used by the constraint on the source database, not the constraint itself.
+The Sink connector uses these key properties to build its `MERGE` statements regardless of whether an equivalent constraint exists on the target database.
+If one is missing, writes still succeed, but without the uniqueness guarantee and index-backed lookups that a matching constraint would provide.
+
 Make sure the corresponding node key, relationship key, or property uniqueness/existence constraints are created on the *target* database before running this strategy in production.
 ====
 

--- a/modules/ROOT/pages/sink/pattern.adoc
+++ b/modules/ROOT/pages/sink/pattern.adoc
@@ -33,7 +33,11 @@ You can also provide relationship patterns to transform it into a path, like `(n
 ----
 
 [NOTE]
-Relationship key properties can only be used with Neo4j Enterprise Edition 5.7 and above, and AuraDB 5.
+====
+The Sink connector accepts relationship key properties (prefixed with `!`) on any Neo4j edition and merges relationships using them.
+However, an actual `RELATIONSHIP KEY` constraint, which enforces uniqueness on those properties, can only be created on Neo4j Enterprise Edition 5.7 and above, and AuraDB 5.
+On Community Edition, or without a matching constraint, writes still succeed but there is no uniqueness guarantee for the relationship key.
+====
 
 == Creating Sink instance
 

--- a/modules/ROOT/pages/source/best-practices.adoc
+++ b/modules/ROOT/pages/source/best-practices.adoc
@@ -111,3 +111,19 @@ Then update the source connector configuration with the refreshed starting offse
 "neo4j.start-from": "USER_PROVIDED",
 "neo4j.start-from.value": "<change identifier from db.cdc.current>"
 ----
+
+[#cdc-use-leader]
+== Decide whether to pin CDC queries to the leader
+
+CDC queries are read operations, so by default (`neo4j.cdc.use-leader` set to `false`), the connector can run them against any cluster member.
+This spreads the read load across followers, which is fine for most workloads.
+
+Under a write heavy workload, followers can lag slightly behind the leader.
+Since the connector may be reading from a follower, this means the CDC events it publishes to Kafka can trail the true state of the database by that same lag.
+
+Set `neo4j.cdc.use-leader` to `true` to always run CDC queries against the leader instead, removing that lag.
+This comes at a cost, all CDC read traffic then competes with the leader's write traffic on the same instance instead of being spread across followers, so it doesn't scale with the cluster the way the default does.
+Reserve `true` for cases where staleness itself is unacceptable, such as high availability setups where downstream consumers must reflect the latest committed change, rather than enabling it by default.
+
+Leadership changes are handled transparently regardless of this setting.
+When the leader changes, the connector's CDC query adapts to the new leader automatically, with no extra configuration or manual restart needed.

--- a/modules/ROOT/pages/source/cdc.adoc
+++ b/modules/ROOT/pages/source/cdc.adoc
@@ -57,6 +57,34 @@ Usually will be the same as authenticated user, but could be different if impers
 [NOTE]
 Only `pattern` settings are mandatory in the above example, and others are optional and can be added based on your requirements.
 
+[#choosing-pattern-form]
+=== Choosing between the list and indexed forms
+
+[%width="100%",cols="1,2",opts=header]
+|===
+| Form
+| When to use it
+
+| Comma-separated list (`neo4j.cdc.topic.\{NAME}.patterns`)
+| One value holds every pattern for the topic, with optional inline `{+prop}`/`{-prop}` property filters. Use this while your patterns only need to select entities and filter properties. It's the more concise of the two forms.
+
+| Indexed (`neo4j.cdc.topic.\{NAME}.patterns.\{INDEX}.pattern` and related keys)
+| Required as soon as a pattern also needs an `operation`, `changesTo`, or `metadata.*` selector, none of which are expressible in the list form. More verbose, but it's the only way to filter beyond entity shape and properties.
+|===
+
+The two forms aren't combined for the same topic. As soon as one pattern for a topic needs the indexed form, define all of that topic's patterns using the indexed form.
+
+[#property-filter-guidance]
+==== Choosing between include and exclude property filters
+
+Both forms support prefixing properties with `+` (include) or `-` (exclude) to control which properties appear in the change event.
+Prefer whichever list is shorter to write for your current schema, but consider how the label evolves over time:
+
+* An exclude list (for example `{-lastLogin}`) stays attached to the label as new properties are added. Any property added to the label later is included in the change event automatically.
+* An include list (for example `{+name,+email}`) only ever contains what's listed. A property added to the label later is excluded from the change event until you update the pattern.
+
+For a label with 6 properties where you want 5 of them, excluding the one you don't want is shorter to write than including the other five, but it also means a 7th property added later shows up unannounced. If you need new properties to stay excluded by default, use the include list even though it's longer.
+
 == Message ordering
 
 The CDC source connector publishes messages in the order of the change records returned by Neo4j CDC.

--- a/modules/ROOT/pages/source/configuration.adoc
+++ b/modules/ROOT/pages/source/configuration.adoc
@@ -79,6 +79,8 @@ Default: `1s`
 Example setting: `"neo4j.cdc.topic.my-topic.patterns": "(:Person {+name}),(:Person)-[:WORKS_FOR]->(:Company),(:Company {-id})"`.
 The change event for `Company` nodes will not include the `id` property.
 
+For guidance on choosing between this form and the indexed form below, see xref:source/cdc.adoc#choosing-pattern-form[Choosing between the list and indexed forms].
+
 | neo4j.cdc.topic.\{NAME}.patterns.\{INDEX}.pattern
 | Indexed graph pattern, with optional event property filters (prefixed with `+` or `-` for inclusion or exclusion respectively).
 
@@ -125,7 +127,9 @@ Default: `false` label:new[Introduced in 5.3.0]
 Default: `30s` label:new[Introduced in 5.3.0]
 
 | neo4j.cdc.use-leader
-| Whether to use the leader instance of the database for CDC queries.
+| Whether to always run CDC queries against the leader instance of the database, instead of any cluster member.
+
+For guidance on choosing between the two, see xref:source/best-practices.adoc#cdc-use-leader[Decide whether to pin CDC queries to the leader].
 
 Default: `false` label:new[Introduced in 5.3.0]
 

--- a/modules/ROOT/pages/source/query.adoc
+++ b/modules/ROOT/pages/source/query.adoc
@@ -108,20 +108,23 @@ curl -X POST http://localhost:8083/connectors \
 This will create a Kafka Connect source instance that will send change event messages derived by the provided query over to the `my-topic` topic, using your preferred serialization format.
 In Control Center, confirm that the Source connector has been created in the Connect tab, under connect-default.
 
-Generated change event messages in this case will have the following structure, which wraps each field into a dedicated structure which is type safe:
+Generated change event messages can be structured in two ways, controlled by the `neo4j.payload-mode` setting.
+The simpler structure, `COMPACT`, only includes the essential fields:
+
+[source,json]
+----
+include::example$producer-data/query.compact.json[]
+----
+
+`COMPACT` is easier to read and to deserialize on the consumer side, but it does not tolerate a property changing type in Neo4j over time.
+If your Cypher query returns properties whose type can change, configure `neo4j.payload-mode` as `EXTENDED` (the default) so that change event messages instead wrap each field into a dedicated, type-safe structure that stays forward compatible across property type changes:
 
 [source,json]
 ----
 include::example$producer-data/query.extended.json[]
 ----
 
-While the above serialized form of the change message is forward compatible in terms of property type changes, it might make the consumer side deserialization logic quite complex and not desired.
-In this case, you can configure `neo4j.payload-mode` setting as `COMPACT` so that change event messages will instead be structured as follows:
-
-[source,json]
-----
-include::example$producer-data/query.compact.json[]
-----
+The trade-off is that this structure is more verbose and can make consumer-side deserialization logic more complex, so reserve it for pipelines where type stability actually matters.
 
 In case you generate complex data structures as part of your Cypher query, you can also use the `RAW_JSON_STRING` payload mode which will produce a raw JSON string representation of the data without any schema compatibility guarantees.
 Although the generated message will look exactly the same as the `COMPACT` mode, it will be encoded as a `STRING` type.


### PR DESCRIPTION
Solves [CONN-1118](https://linear.app/neo4j/issue/CONN-1118/kafka-docs-follow-up-for-remaining-undone-items)

**What**

Adds decision-making guidance for sink strategy and CDC pattern configuration, and corrects several misleading claims about constraints and payload modes.

**Why**

Several pages presented options (sink strategies, CDC pattern forms, payload-mode, use-leader) without explaining when to choose one over the other, and a few statements were inaccurate: the Pattern page implied relationship key properties require Enterprise Edition, and the CDC sink page didn't mention that the Schema strategy merges on key property names without any constraint existing on the target database.

**Changes**

New sink best practices page
- Added sink/best-practices.adoc with a decision table for choosing between the CDC, Pattern, CUD, and Cypher sink strategies
- Registered the page in content-nav.adoc and linked it from the sink landing page (sink.adoc)

Accuracy fixes around constraints
- sink/cdc.adoc: added an IMPORTANT admonition clarifying that the Schema strategy builds MERGE statements from key property names in the change event and does not verify a matching constraint exists on the target database; users must create constraints on the target themselves
- sink/pattern.adoc: corrected the note about relationship key properties. The connector accepts them on any edition; only the enforcing RELATIONSHIP KEY constraint requires Enterprise Edition 5.7+ or AuraDB 5

Source CDC configuration guidance
- source/cdc.adoc: added sections comparing the comma-separated list and indexed pattern forms, and include (+) vs. exclude (-) property filters, including how each behaves as the schema evolves
- source/best-practices.adoc: added a section on when to set neo4j.cdc.use-leader, covering follower lag vs. leader load trade-offs and noting that leadership changes are handled transparently
- source/configuration.adoc: cross-linked both new sections from the patterns and neo4j.cdc.use-leader setting entries

Query source payload modes
- source/query.adoc: restructured the payload-mode section to present COMPACT first, clarify that EXTENDED is the default, and explain the actual trade-off (type-change tolerance vs. deserialization complexity)