### PR TITLE
Create one quick start per kafka strategy

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -4,11 +4,13 @@
 
 * *Getting started*
 * xref::installation.adoc[]
-* Quickstart
+* xref:quickstart/index.adoc[Quickstart]
 ** xref:quickstart/sink-cypher.adoc[Sink with Cypher]
 ** xref:quickstart/sink-pattern.adoc[Sink with Pattern]
 ** xref:quickstart/sink-cud.adoc[Sink with CUD]
 ** xref:quickstart/sink-cdc.adoc[Sink with Change Data Capture]
+** xref:quickstart/source-cdc.adoc[Source with Change Data Capture]
+** xref:quickstart/source-query.adoc[Source with Query]
 ** xref::quickstart-docker.adoc[Confluent Platform]
 ** xref::quickstart-confluent-cloud.adoc[Confluent Cloud]
 // * xref::amazon-msk.adoc[Amazon MSK quickstart]

--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -5,6 +5,10 @@
 * *Getting started*
 * xref::installation.adoc[]
 * Quickstart
+** xref:quickstart/sink-cypher.adoc[Sink with Cypher]
+** xref:quickstart/sink-pattern.adoc[Sink with Pattern]
+** xref:quickstart/sink-cud.adoc[Sink with CUD]
+** xref:quickstart/sink-cdc.adoc[Sink with Change Data Capture]
 ** xref::quickstart-docker.adoc[Confluent Platform]
 ** xref::quickstart-confluent-cloud.adoc[Confluent Cloud]
 // * xref::amazon-msk.adoc[Amazon MSK quickstart]

--- a/modules/ROOT/examples/docker-data/quickstart.sink.cdc-schema.avro.json
+++ b/modules/ROOT/examples/docker-data/quickstart.sink.cdc-schema.avro.json
@@ -11,6 +11,6 @@
     "neo4j.authentication.type": "BASIC",
     "neo4j.authentication.basic.username": "neo4j",
     "neo4j.authentication.basic.password": "password",
-    "neo4j.cdc.schema.topics": "creates,updates.deletes"
+    "neo4j.cdc.schema.topics": "creates,updates,deletes"
   }
 }

--- a/modules/ROOT/examples/docker-data/quickstart.sink.cdc-schema.json-embedded.json
+++ b/modules/ROOT/examples/docker-data/quickstart.sink.cdc-schema.json-embedded.json
@@ -1,0 +1,17 @@
+{
+  "name": "Neo4jSinkCdcSchemaQuickstart",
+  "config": {
+    "topics": "cdc-events",
+    "connector.class": "org.neo4j.connectors.kafka.sink.Neo4jConnector",
+    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "key.converter.schemas.enable": true,
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": true,
+    "neo4j.uri": "neo4j://neo4j:7687",
+    "neo4j.authentication.type": "BASIC",
+    "neo4j.authentication.basic.username": "neo4j",
+    "neo4j.authentication.basic.password": "password",
+    "neo4j.database": "target",
+    "neo4j.cdc.schema.topics": "cdc-events"
+  }
+}

--- a/modules/ROOT/examples/docker-data/quickstart.sink.cdc-schema.json.json
+++ b/modules/ROOT/examples/docker-data/quickstart.sink.cdc-schema.json.json
@@ -13,6 +13,6 @@
     "neo4j.authentication.type": "BASIC",
     "neo4j.authentication.basic.username": "neo4j",
     "neo4j.authentication.basic.password": "password",
-    "neo4j.cdc.schema.topics": "creates,updates.deletes"
+    "neo4j.cdc.schema.topics": "creates,updates,deletes"
   }
 }

--- a/modules/ROOT/examples/docker-data/quickstart.sink.cdc-schema.protobuf.json
+++ b/modules/ROOT/examples/docker-data/quickstart.sink.cdc-schema.protobuf.json
@@ -15,6 +15,6 @@
     "neo4j.authentication.type": "BASIC",
     "neo4j.authentication.basic.username": "neo4j",
     "neo4j.authentication.basic.password": "password",
-    "neo4j.cdc.schema.topics": "creates,updates.deletes"
+    "neo4j.cdc.schema.topics": "creates,updates,deletes"
   }
 }

--- a/modules/ROOT/examples/docker-data/quickstart.sink.cud.json-raw.json
+++ b/modules/ROOT/examples/docker-data/quickstart.sink.cud.json-raw.json
@@ -1,0 +1,15 @@
+{
+  "name": "Neo4jSinkCudQuickstart",
+  "config": {
+    "topics": "crm",
+    "connector.class": "org.neo4j.connectors.kafka.sink.Neo4jConnector",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": false,
+    "neo4j.uri": "neo4j://neo4j:7687",
+    "neo4j.authentication.type": "BASIC",
+    "neo4j.authentication.basic.username": "neo4j",
+    "neo4j.authentication.basic.password": "password",
+    "neo4j.cud.topics": "crm"
+  }
+}

--- a/modules/ROOT/examples/docker-data/quickstart.sink.cypher.json-raw.json
+++ b/modules/ROOT/examples/docker-data/quickstart.sink.cypher.json-raw.json
@@ -1,0 +1,15 @@
+{
+  "name": "Neo4jSinkCypherQuickstart",
+  "config": {
+    "topics": "people",
+    "connector.class": "org.neo4j.connectors.kafka.sink.Neo4jConnector",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": false,
+    "neo4j.uri": "neo4j://neo4j:7687",
+    "neo4j.authentication.type": "BASIC",
+    "neo4j.authentication.basic.username": "neo4j",
+    "neo4j.authentication.basic.password": "password",
+    "neo4j.cypher.topic.people": "WITH __value AS person MERGE (p:Person {name: person.name, surname: person.surname}) SET p.fullName = person.name + ' ' + person.surname MERGE (c:City {name: person.city}) MERGE (p)-[:LIVES_IN]->(c)"
+  }
+}

--- a/modules/ROOT/examples/docker-data/quickstart.sink.pattern.json-raw.json
+++ b/modules/ROOT/examples/docker-data/quickstart.sink.pattern.json-raw.json
@@ -1,0 +1,17 @@
+{
+  "name": "Neo4jSinkPatternQuickstart",
+  "config": {
+    "topics": "users,purchases",
+    "connector.class": "org.neo4j.connectors.kafka.sink.Neo4jConnector",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": false,
+    "neo4j.uri": "neo4j://neo4j:7687",
+    "neo4j.authentication.type": "BASIC",
+    "neo4j.authentication.basic.username": "neo4j",
+    "neo4j.authentication.basic.password": "password",
+    "neo4j.pattern.merge-node-properties": true,
+    "neo4j.pattern.topic.users": "(:User{!userId, name, surname})",
+    "neo4j.pattern.topic.purchases": "(:User{!userId})-[:BOUGHT{price, currency}]->(:Product{!productId, name: productName})"
+  }
+}

--- a/modules/ROOT/examples/docker-data/quickstart.source.cdc.json-embedded.json
+++ b/modules/ROOT/examples/docker-data/quickstart.source.cdc.json-embedded.json
@@ -1,0 +1,21 @@
+{
+  "name": "Neo4jSourceCdcQuickstart",
+  "config": {
+    "connector.class": "org.neo4j.connectors.kafka.source.Neo4jConnector",
+    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "key.converter.schemas.enable": true,
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": true,
+    "neo4j.uri": "neo4j://neo4j:7687",
+    "neo4j.authentication.type": "BASIC",
+    "neo4j.authentication.basic.username": "neo4j",
+    "neo4j.authentication.basic.password": "password",
+    "neo4j.database": "source",
+    "neo4j.source-strategy": "CDC",
+    "neo4j.start-from": "NOW",
+    "neo4j.cdc.poll-interval": "1s",
+    "neo4j.cdc.poll-duration": "5s",
+    "neo4j.cdc.topic.cdc-events.patterns.0.pattern": "(:Person)",
+    "neo4j.cdc.topic.cdc-events.patterns.1.pattern": "(:Person)-[:KNOWS]->(:Person)"
+  }
+}

--- a/modules/ROOT/examples/docker-data/quickstart.source.cdc.json-embedded.json
+++ b/modules/ROOT/examples/docker-data/quickstart.source.cdc.json-embedded.json
@@ -15,7 +15,6 @@
     "neo4j.start-from": "NOW",
     "neo4j.cdc.poll-interval": "1s",
     "neo4j.cdc.poll-duration": "5s",
-    "neo4j.cdc.topic.cdc-events.patterns.0.pattern": "(:Person)",
-    "neo4j.cdc.topic.cdc-events.patterns.1.pattern": "(:Person)-[:KNOWS]->(:Person)"
+    "neo4j.cdc.topic.cdc-events.patterns": "(:Person),(:Person)-[:KNOWS]->(:Person)"
   }
 }

--- a/modules/ROOT/examples/docker-data/quickstart.source.cdc.operations.json-embedded.json
+++ b/modules/ROOT/examples/docker-data/quickstart.source.cdc.operations.json-embedded.json
@@ -1,0 +1,24 @@
+{
+  "name": "Neo4jSourceCdcOperationsQuickstart",
+  "config": {
+    "connector.class": "org.neo4j.connectors.kafka.source.Neo4jConnector",
+    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "key.converter.schemas.enable": true,
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": true,
+    "neo4j.uri": "neo4j://neo4j:7687",
+    "neo4j.authentication.type": "BASIC",
+    "neo4j.authentication.basic.username": "neo4j",
+    "neo4j.authentication.basic.password": "password",
+    "neo4j.source-strategy": "CDC",
+    "neo4j.start-from": "NOW",
+    "neo4j.cdc.poll-interval": "1s",
+    "neo4j.cdc.poll-duration": "5s",
+    "neo4j.cdc.topic.creates.patterns.0.pattern": "(:Person)",
+    "neo4j.cdc.topic.creates.patterns.0.operation": "CREATE",
+    "neo4j.cdc.topic.updates.patterns.0.pattern": "(:Person)",
+    "neo4j.cdc.topic.updates.patterns.0.operation": "UPDATE",
+    "neo4j.cdc.topic.deletes.patterns.0.pattern": "(:Person)",
+    "neo4j.cdc.topic.deletes.patterns.0.operation": "DELETE"
+  }
+}

--- a/modules/ROOT/examples/docker-data/quickstart.source.query.json-embedded.json
+++ b/modules/ROOT/examples/docker-data/quickstart.source.query.json-embedded.json
@@ -1,0 +1,21 @@
+{
+  "name": "Neo4jSourceQueryQuickstart",
+  "config": {
+    "connector.class": "org.neo4j.connectors.kafka.source.Neo4jConnector",
+    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "key.converter.schemas.enable": true,
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": true,
+    "neo4j.uri": "neo4j://neo4j:7687",
+    "neo4j.authentication.type": "BASIC",
+    "neo4j.authentication.basic.username": "neo4j",
+    "neo4j.authentication.basic.password": "password",
+    "neo4j.source-strategy": "QUERY",
+    "neo4j.start-from": "EARLIEST",
+    "neo4j.query.topic": "readings",
+    "neo4j.query": "MATCH (r:Reading) WHERE r.timestamp > $lastCheck RETURN r.sensor AS sensor, r.celsius AS celsius, r.timestamp AS timestamp ORDER BY r.timestamp",
+    "neo4j.query.streaming-property": "timestamp",
+    "neo4j.query.poll-interval": "1s",
+    "neo4j.query.poll-duration": "5s"
+  }
+}

--- a/modules/ROOT/pages/quickstart/index.adoc
+++ b/modules/ROOT/pages/quickstart/index.adoc
@@ -1,0 +1,119 @@
+= Quickstart: choose a strategy
+:xrefstyle: full
+
+ifdef::env-docs[]
+[abstract]
+--
+Pick the strategy that matches what you are trying to do, then follow its guide end to end.
+--
+endif::env-docs[]
+
+The {product-name} does not have a single mode of operation.
+Which component you use — and which **strategy** within it — depends on the direction your data
+flows and the shape of your messages.
+Each quickstart below is self-contained and runnable on a local Docker stack.
+
+== Which direction?
+
+Sink:: Kafka **into** Neo4j. Something else produces messages; you want them in the graph.
+Source:: Neo4j **out to** Kafka. The database is the producer; something else consumes.
+
+Both at once is possible — the xref:quickstart/sink-cdc.adoc[Sink with CDC] guide does exactly that
+to replicate one Neo4j database into another.
+
+== Sink: getting Kafka messages into Neo4j
+
+[cols="1,2,1",opts=header]
+|===
+| Your situation | Strategy | Quickstart
+
+| You control the target graph model and need real write logic — derived values, conditionals,
+several clauses per message.
+| xref:sink/cypher.adoc[Cypher] — your Cypher statement, run per message.
+| xref:quickstart/sink-cypher.adoc[Sink with Cypher]
+
+| Your messages map onto nodes and relationships field-for-field, and you would rather declare the
+mapping than write a query.
+| xref:sink/pattern.adoc[Pattern] — a Cypher-like pattern per topic; the connector generates the
+`MERGE`.
+| xref:quickstart/sink-pattern.adoc[Sink with Pattern]
+
+| Each message already states its own intent, and deletes are part of the stream.
+| xref:sink/cud.adoc[CUD] — every message carries an `op` field.
+| xref:quickstart/sink-cud.adoc[Sink with CUD]
+
+| The messages were produced by Neo4j — a source connector or Neo4j Streams — and you are
+replicating into another database.
+| xref:sink/cdc.adoc[Change Data Capture] — change events reapplied to the target.
+| xref:quickstart/sink-cdc.adoc[Sink with CDC]
+|===
+
+If two of those look plausible, the tie-breakers are usually:
+
+* **Pattern vs Cypher** — can you express the mapping without computing anything? Pattern only maps;
+  it cannot derive a value or branch.
+* **CUD vs Pattern** — does the operation vary per message? Pattern always upserts. Pattern is also
+  limited to one mapping per topic, whereas CUD carries any label or relationship type on one topic.
+* **CDC vs anything else** — did the messages come from Neo4j? If not, CDC is the wrong answer; it
+  expects a specific event format and header.
+
+== Source: getting Neo4j changes into Kafka
+
+[cols="1,2,1",opts=header]
+|===
+| Your situation | Strategy | Quickstart
+
+| You need every change, including deletes, in near real time, without changing your graph model.
+| xref:source/cdc.adoc[Change Data Capture] — Neo4j's own change feed.
+| xref:quickstart/source-cdc.adoc[Source with CDC]
+
+| You want a specific projection, you are on Community Edition, or you cannot enable CDC.
+| xref:source/query.adoc[Query] — your Cypher query, polled on an interval.
+| xref:quickstart/source-query.adoc[Source with Query]
+|===
+
+Two differences decide it in most cases:
+
+* **Deletes.** A polling query cannot see a node that no longer exists. Only CDC reports deletes,
+  unless you adopt soft deletes.
+* **Edition.** CDC needs Enterprise Edition or Aura Enterprise. Query works anywhere.
+
+== What every quickstart assumes
+
+All of them run the same local stack — Neo4j, a Kafka broker, Kafka Connect and Schema Registry via
+Docker Compose — and differ only in connector configuration and message shape.
+So it is reasonable to work through one, then swap the connector to try another.
+
+Serialization differs by strategy, and it is the detail most likely to trip you up:
+
+[cols="1,2",opts=header]
+|===
+| Strategy | Serialization
+
+| Sink — Cypher, Pattern, CUD
+| Plain JSON works, so no Schema Registry is needed and messages can be produced by hand with
+`kafka-console-producer`.
+
+| Sink — CDC
+| Needs a schema-carrying converter **and** messages produced by a real source connector. Change
+events cannot be written by hand.
+
+| Source — CDC, Query
+| Always produces messages with schemas. A schemaless converter will not work.
+|===
+
+Where a schema is required, these guides use `JsonConverter` with `schemas.enable=true`, which
+embeds the schema in each message and needs no Schema Registry.
+Avro and Protobuf are covered on each page, and in xref:source/schema-registry.adoc[Schema Registry].
+
+== Deploying somewhere other than Docker
+
+The strategy guides use a local Docker Compose stack so they can be run start to finish.
+The strategy configuration is identical wherever you deploy it — only installation and connection
+details change:
+
+* xref:installation.adoc[Installation] — Confluent Platform, Confluent Hub, standalone Kafka Connect.
+* xref:quickstart-confluent-cloud.adoc[Quickstart for Confluent Cloud] — custom connectors, endpoints
+  and API keys.
+* xref:quickstart-docker.adoc[Quickstart for Confluent Platform] — a combined source-and-sink
+  walkthrough on one database.

--- a/modules/ROOT/pages/quickstart/sink-cdc.adoc
+++ b/modules/ROOT/pages/quickstart/sink-cdc.adoc
@@ -70,39 +70,7 @@ Avro and Protobuf work the same way — see <<other-formats>>.
 
 === Start the environment
 
-Copy the following Docker Compose file into a new directory.
-
-.docker-compose.yml
-[source,yaml]
-----
-include::example$docker-data/docker-compose.yml[]
-----
-
-Copy the {product-name} JAR into a directory named `plugins` next to your `docker-compose.yml`:
-
-[source,text,subs="attributes+"]
-----
-quickstart/
-├─ plugins/
-│  ├─ neo4j-kafka-connect-{exact-connector-version}.jar
-├─ docker-compose.yml
-----
-
-[source,bash]
-----
-docker compose up -d
-docker compose ps
-----
-
-Wait until every service reports healthy — 90-120 seconds on a first run.
-Then confirm the plugin loaded:
-
-[source,bash]
-----
-curl -s http://localhost:8083/connector-plugins | grep -o 'Neo4jConnector'
-----
-
-You should see it twice — once for the source connector and once for the sink.
+include::partial$quickstart-environment.adoc[]
 
 == Step 1: Create the two databases
 

--- a/modules/ROOT/pages/quickstart/sink-cdc.adoc
+++ b/modules/ROOT/pages/quickstart/sink-cdc.adoc
@@ -1,0 +1,367 @@
+= Quickstart: Sink with Change Data Capture
+:xrefstyle: full
+
+ifdef::env-docs[]
+[abstract]
+--
+Replicate changes from one Neo4j database into another through Kafka.
+--
+endif::env-docs[]
+
+== When to use the CDC strategy
+
+Use the xref:sink/cdc.adoc[Change Data Capture strategy] when the messages you are consuming were
+**produced by Neo4j** — either by a xref:source/cdc.adoc[source connector using the CDC strategy]
+or by the deprecated link:{page-canonical-root}/kafka-streams[Neo4j Streams] plugin.
+The connector understands the change-event format natively and reapplies each change to the target
+database.
+
+Pick it when you are:
+
+* replicating a Neo4j database into another Neo4j or Aura database;
+* migrating between instances with Kafka in the middle;
+* fanning one database out to several downstream Neo4j instances.
+
+Consider a different strategy if:
+
+xref:sink/cypher.adoc[Cypher]:: Your messages come from anywhere other than Neo4j, or you want to
+reshape them on the way in.
+xref:sink/pattern.adoc[Pattern]:: Your messages are ordinary business events that map onto nodes
+and relationships.
+xref:sink/cud.adoc[CUD]:: Your producer emits its own explicit create, update and delete
+instructions.
+
+[IMPORTANT]
+====
+Unlike the other sink strategies, **this one cannot be driven by hand-written messages.**
+A change event must arrive as a schema-carrying structure *and* with the
+`neo4j.source.cdc.id` header that the source connector attaches; without the header the connector
+treats the message as the legacy Neo4j Streams format instead.
+So this guide runs a real source connector, which is also the only realistic use case.
+====
+
+== What you will build
+
+Two connectors and two databases, with Kafka in between:
+
+[source,text]
+----
+source database ──> Source connector (CDC) ──> cdc-events topic ──> Sink connector ──> target database
+----
+
+Two separate databases are essential.
+If the sink wrote back into the source database, its writes would be captured by CDC, republished,
+and applied again — an endless loop.
+
+[NOTE]
+====
+This guide uses `JsonConverter` with `schemas.enable=true`, which embeds the schema in every
+message.
+That satisfies the schema requirement **without needing Schema Registry**, keeping the setup small.
+Avro and Protobuf work the same way — see <<other-formats>>.
+====
+
+== Prerequisites
+
+* Docker Compose v2.20.3 or later.
+* The {product-name} archive, unpacked as described in xref:installation.adoc[].
+* Neo4j Enterprise Edition or Aura Enterprise. CDC and multiple databases are not available in
+  Community Edition.
+
+=== Start the environment
+
+Copy the following Docker Compose file into a new directory.
+
+.docker-compose.yml
+[source,yaml]
+----
+include::example$docker-data/docker-compose.yml[]
+----
+
+Copy the {product-name} JAR into a directory named `plugins` next to your `docker-compose.yml`:
+
+[source,text,subs="attributes+"]
+----
+quickstart/
+├─ plugins/
+│  ├─ neo4j-kafka-connect-{exact-connector-version}.jar
+├─ docker-compose.yml
+----
+
+[source,bash]
+----
+docker compose up -d
+docker compose ps
+----
+
+Wait until every service reports healthy — 90-120 seconds on a first run.
+Then confirm the plugin loaded:
+
+[source,bash]
+----
+curl -s http://localhost:8083/connector-plugins | grep -o 'Neo4jConnector'
+----
+
+You should see it twice — once for the source connector and once for the sink.
+
+== Step 1: Create the two databases
+
+In Neo4j Browser at \http://localhost:7474 (`neo4j` / `password`), against the `system` database:
+
+[source,cypher]
+----
+CREATE DATABASE source IF NOT EXISTS;
+CREATE DATABASE target IF NOT EXISTS;
+----
+
+== Step 2: Enable CDC on the source database only
+
+[source,cypher]
+----
+ALTER DATABASE source SET OPTION txLogEnrichment 'FULL';
+----
+
+Leave `target` alone.
+CDC stays off there, which is what breaks the replication loop.
+
+For more on enabling CDC, see
+link:{page-canonical-root}/cdc/current/get-started/self-managed[Change Data Capture > Enable CDC >
+Neo4j DBMS] for on-prem installations and
+link:{page-canonical-root}/cdc/current/get-started/aura[Change Data Capture > Enable CDC > Aura]
+for Aura.
+
+[NOTE]
+On Aura, CDC is reset to `OFF` when an instance is paused and resumed.
+Re-enable it and follow xref:source/best-practices.adoc#source-cdc-cursor-recovery[CDC cursor
+recovery] before restarting the source connector.
+
+== Step 3: Add key constraints on both databases
+
+The schema sub-strategy merges entities using the key properties named in each change event.
+Those names travel with the event, but the constraints themselves do not — so create matching ones
+on both sides.
+
+Against `source` **and** again against `target`:
+
+[source,cypher]
+----
+CREATE CONSTRAINT person_name IF NOT EXISTS
+FOR (p:Person) REQUIRE (p.first_name, p.last_name) IS NODE KEY;
+----
+
+On `source` this constraint is what puts `first_name` and `last_name` into the event's `keys`
+field. On `target` it gives the generated `MERGE` an index to use and enforces uniqueness.
+
+[IMPORTANT]
+Without a constraint on `source`, change events carry no key properties and the schema
+sub-strategy has nothing to merge on.
+Without one on `target`, writes still succeed but lose both uniqueness and index-backed lookup.
+
+== Step 4: Create the source connector
+
+Save the following as `source.cdc.neo4j.json`:
+
+ifdef::backend-pdf[]
+.quickstart.source.cdc.json-embedded.json
+endif::[]
+[source,json]
+----
+include::example$docker-data/quickstart.source.cdc.json-embedded.json[]
+----
+
+Both patterns publish to the same `cdc-events` topic — one for `:Person` nodes, one for `:KNOWS`
+relationships between them. `neo4j.start-from: NOW` means only changes made after the connector
+starts are captured.
+
+[source,bash]
+----
+curl -X POST http://localhost:8083/connectors \
+  -H 'Content-Type:application/json' \
+  -H 'Accept:application/json' \
+  -d @source.cdc.neo4j.json
+
+curl -s http://localhost:8083/connectors/Neo4jSourceCdcQuickstart/status
+----
+
+== Step 5: Create the sink connector
+
+Save the following as `sink.cdc.neo4j.json`:
+
+ifdef::backend-pdf[]
+.quickstart.sink.cdc-schema.json-embedded.json
+endif::[]
+[source,json]
+----
+include::example$docker-data/quickstart.sink.cdc-schema.json-embedded.json[]
+----
+
+`neo4j.cdc.schema.topics` selects the schema sub-strategy, and `neo4j.database` points the writes
+at `target`.
+The converters match the source connector's exactly — this is not optional, as the sink has to
+reconstruct the change events the source serialized.
+
+[source,bash]
+----
+curl -X POST http://localhost:8083/connectors \
+  -H 'Content-Type:application/json' \
+  -H 'Accept:application/json' \
+  -d @sink.cdc.neo4j.json
+
+curl -s http://localhost:8083/connectors/Neo4jSinkCdcSchemaQuickstart/status
+----
+
+Both connectors and both tasks should report `RUNNING` before you continue.
+
+== Step 6: Make some changes and watch them replicate
+
+Against the **`source`** database:
+
+[source,cypher]
+----
+CREATE (:Person {first_name: 'John', last_name: 'Doe', email: 'john.doe@example.com'});
+CREATE (:Person {first_name: 'Mary', last_name: 'Doe', email: 'mary.doe@example.com'});
+MATCH (j:Person {first_name: 'John'}), (m:Person {first_name: 'Mary'})
+CREATE (j)-[:KNOWS {since: date('2012-01-01')}]->(m);
+----
+
+Now switch to the **`target`** database — `:use target` in Browser — and read it back:
+
+[source,cypher]
+----
+MATCH (p:Person) RETURN p.first_name AS first, p.last_name AS last, p.email AS email ORDER BY first
+----
+
+[source,text]
+----
+first    last    email
+"John"   "Doe"   "john.doe@example.com"
+"Mary"   "Doe"   "mary.doe@example.com"
+----
+
+[source,cypher]
+----
+MATCH (a:Person)-[k:KNOWS]->(b:Person) RETURN a.first_name AS from, b.first_name AS to, k.since AS since
+----
+
+Updates and deletes replicate too. Back on `source`:
+
+[source,cypher]
+----
+MATCH (p:Person {first_name: 'John'}) SET p.email = 'john.doe@neo4j.com';
+MATCH (p:Person {first_name: 'Mary'}) DETACH DELETE p;
+----
+
+On `target`, John's email is updated and Mary is gone, along with the `:KNOWS` relationship.
+
+== The two sub-strategies
+
+<<_step_5_create_the_sink_connector,Step 5>> used the **schema** sub-strategy. There is a second
+one, and the difference is what each merges on.
+
+[cols="1,2,2",opts=header]
+|===
+| | `neo4j.cdc.schema.topics` | `neo4j.cdc.source-id.topics`
+
+| Merges on
+| the key properties named in the event, from the source database's constraints
+| the source database's internal `elementId`
+
+| Needs constraints
+| yes, on both databases
+| no
+
+| Target graph
+| natural keys, no extra properties
+| an extra label and property holding the source id
+
+| Use when
+| the target should look like the source, and you have keys
+| there are no usable keys, or you want a faithful id-for-id copy
+|===
+
+To try the Source ID sub-strategy, delete the sink connector and register one that swaps the
+strategy key:
+
+[source,bash]
+----
+curl -X DELETE http://localhost:8083/connectors/Neo4jSinkCdcSchemaQuickstart
+----
+
+[source,json]
+----
+  "neo4j.cdc.source-id.topics": "cdc-events",
+  "neo4j.cdc.source-id.label-name": "SourceEvent",
+  "neo4j.cdc.source-id.property-name": "sourceId"
+----
+
+Every replicated entity then also carries a `:SourceEvent` label and a `sourceId` property holding
+the source database's element id.
+Both extra settings are optional; the defaults are shown above.
+
+[[other-formats]]
+== Using Avro or Protobuf
+
+The requirement is a converter that **carries schemas** — plain JSON with
+`schemas.enable=false` cannot work here, because the connector needs a structured value rather
+than a plain map.
+
+`JsonConverter` with `schemas.enable=true` is used above because it needs no extra
+infrastructure. To use the Schema Registry included in the Compose stack instead, set the same
+converter on both connectors:
+
+[source,json]
+----
+  "key.converter": "io.confluent.connect.avro.AvroConverter",
+  "key.converter.schema.registry.url": "http://schema-registry:8081",
+  "value.converter": "io.confluent.connect.avro.AvroConverter",
+  "value.converter.schema.registry.url": "http://schema-registry:8081"
+----
+
+Avro and Protobuf also preserve temporal and numeric types more faithfully than embedded-schema
+JSON. See xref:source/schema-registry.adoc[Schema Registry] and
+xref:sink/connect-types.adoc[Type support].
+
+[IMPORTANT]
+The source and sink connectors must run the **same version** of the {product-name}, and use
+matching converters. A mismatch shows up as deserialization failures on the sink.
+
+== Troubleshooting
+
+[source,bash]
+----
+curl -s http://localhost:8083/connectors/Neo4jSourceCdcQuickstart/status
+curl -s http://localhost:8083/connectors/Neo4jSinkCdcSchemaQuickstart/status
+docker compose logs connect
+----
+
+Confirm events are actually reaching Kafka before blaming the sink:
+
+[source,bash]
+----
+docker compose exec broker kafka-console-consumer \
+  --bootstrap-server broker:29092 --topic cdc-events --from-beginning --max-messages 1
+----
+
+Nothing in the topic:: CDC is not enabled on `source`, or the changes predate the connector.
+`neo4j.start-from` is `NOW`, so only changes after startup are captured. Verify with
+`SHOW DATABASE source YIELD name, options`.
+`unexpected message value type`:: The sink is reading with a schemaless converter. Both connectors
+need `schemas.enable=true`, or Avro/Protobuf.
+Events arrive but nothing is written, no error:: The value converter carries no
+`neo4j.source.cdc.id` header, so the message is being parsed as the legacy Neo4j Streams format.
+Check that the messages really came from a Neo4j source connector.
+Nodes duplicated on the target:: No key constraint on `target`, so `MERGE` had nothing unique to
+match. See <<_step_3_add_key_constraints_on_both_databases,Step 3>>.
+Nodes merged into one on the target:: The source constraint covers fewer properties than you
+expected, so several source nodes share one key. Check the constraint on `source`.
+Writes loop endlessly:: CDC is enabled on `target` as well. Turn it off with
+`ALTER DATABASE target SET OPTION txLogEnrichment 'OFF'`.
+
+== Next steps
+
+* xref:sink/cdc.adoc[Change Data Capture strategy] — both sub-strategies in full, including how
+  each change type maps onto Cypher.
+* xref:source/cdc.adoc[Source CDC strategy] — pattern syntax, operations and metadata filters.
+* xref:source/best-practices.adoc[Source best practices] — cursor recovery and sizing.
+* xref:sink/error-handling.adoc[Error handling] — dead letter queues and error tolerance.
+* xref:sink/monitoring.adoc[Monitoring] — JMX metrics exposed by the sink connector.

--- a/modules/ROOT/pages/quickstart/sink-cdc.adoc
+++ b/modules/ROOT/pages/quickstart/sink-cdc.adoc
@@ -22,15 +22,6 @@ Pick it when you are:
 * migrating between instances with Kafka in the middle;
 * fanning one database out to several downstream Neo4j instances.
 
-Consider a different strategy if:
-
-xref:sink/cypher.adoc[Cypher]:: Your messages come from anywhere other than Neo4j, or you want to
-reshape them on the way in.
-xref:sink/pattern.adoc[Pattern]:: Your messages are ordinary business events that map onto nodes
-and relationships.
-xref:sink/cud.adoc[CUD]:: Your producer emits its own explicit create, update and delete
-instructions.
-
 [IMPORTANT]
 ====
 Unlike the other sink strategies, **this one cannot be driven by hand-written messages.**
@@ -90,7 +81,6 @@ ALTER DATABASE source SET OPTION txLogEnrichment 'FULL';
 ----
 
 Leave `target` alone.
-CDC stays off there, which is what breaks the replication loop.
 
 For more on enabling CDC, see
 link:{page-canonical-root}/cdc/current/get-started/self-managed[Change Data Capture > Enable CDC >
@@ -288,10 +278,6 @@ converter on both connectors:
 Avro and Protobuf also preserve temporal and numeric types more faithfully than embedded-schema
 JSON. See xref:source/schema-registry.adoc[Schema Registry] and
 xref:sink/connect-types.adoc[Type support].
-
-[IMPORTANT]
-The source and sink connectors must run the **same version** of the {product-name}, and use
-matching converters. A mismatch shows up as deserialization failures on the sink.
 
 == Troubleshooting
 

--- a/modules/ROOT/pages/quickstart/sink-cud.adoc
+++ b/modules/ROOT/pages/quickstart/sink-cud.adoc
@@ -61,39 +61,7 @@ See <<other-formats>> for Avro, Protobuf and JSON Schema.
 
 === Start the environment
 
-Copy the following Docker Compose file into a new directory.
-
-.docker-compose.yml
-[source,yaml]
-----
-include::example$docker-data/docker-compose.yml[]
-----
-
-Copy the {product-name} JAR into a directory named `plugins` next to your `docker-compose.yml`:
-
-[source,text,subs="attributes+"]
-----
-quickstart/
-├─ plugins/
-│  ├─ neo4j-kafka-connect-{exact-connector-version}.jar
-├─ docker-compose.yml
-----
-
-[source,bash]
-----
-docker compose up -d
-docker compose ps
-----
-
-Wait until every service reports healthy — 90-120 seconds on a first run.
-Then confirm the plugin loaded:
-
-[source,bash]
-----
-curl -s http://localhost:8083/connector-plugins | grep -o 'sink.Neo4jConnector'
-----
-
-You can log in to Neo4j Browser at \http://localhost:7474 with `neo4j` / `password`.
+include::partial$quickstart-environment.adoc[]
 
 [TIP]
 The CUD strategy does not require Change Data Capture, so there is nothing to enable on the

--- a/modules/ROOT/pages/quickstart/sink-cud.adoc
+++ b/modules/ROOT/pages/quickstart/sink-cud.adoc
@@ -1,0 +1,361 @@
+= Quickstart: Sink with CUD
+:xrefstyle: full
+
+ifdef::env-docs[]
+[abstract]
+--
+Apply create, update, merge and delete operations carried inside the Kafka messages themselves.
+--
+endif::env-docs[]
+
+== When to use the CUD strategy
+
+Use the xref:sink/cud.adoc[CUD strategy] when each message **states its own operation**.
+Instead of you declaring a mapping once in the connector configuration, every message carries an
+`op` field telling the connector whether to create, update, merge or delete — and the connector
+generates the matching Cypher.
+
+Pick it when:
+
+* the producer already knows the intent of each change, and deletes are part of the stream;
+* one topic must carry operations on several different labels and relationship types;
+* you want a single stream to drive a full entity lifecycle.
+
+Consider a different strategy if:
+
+xref:sink/pattern.adoc[Pattern]:: Every message is an upsert of the same shape. Patterns are much
+less verbose when the operation never varies.
+xref:sink/cypher.adoc[Cypher]:: You need derived values or logic the CUD format cannot express.
+CUD is a fixed vocabulary, not a query language.
+xref:sink/cdc.adoc[Change Data Capture]:: Your messages came from a Neo4j source connector or
+Neo4j Streams. CDC already encodes operations in its own format.
+
+[TIP]
+Unlike xref:sink/pattern.adoc[Pattern], CUD has no one-mapping-per-topic restriction — a single
+topic can carry nodes and relationships of any label. This guide uses one topic for everything.
+
+== What you will build
+
+One connector consuming a `crm` topic, driving a full lifecycle:
+
+[source,text]
+----
+crm topic ──> create  (:Customer), (:Product)
+              create  (:Customer)-[:PURCHASED]->(:Product)
+              update  (:Customer)
+              merge   (:Customer)
+              delete  (:Customer)
+----
+
+No source connector is involved — messages are produced by hand, the way an external system
+would produce them.
+
+[NOTE]
+This guide uses plain JSON messages, so no Schema Registry is required.
+See <<other-formats>> for Avro, Protobuf and JSON Schema.
+
+== Prerequisites
+
+* Docker Compose v2.20.3 or later.
+* The {product-name} archive, unpacked as described in xref:installation.adoc[].
+
+=== Start the environment
+
+Copy the following Docker Compose file into a new directory.
+
+.docker-compose.yml
+[source,yaml]
+----
+include::example$docker-data/docker-compose.yml[]
+----
+
+Copy the {product-name} JAR into a directory named `plugins` next to your `docker-compose.yml`:
+
+[source,text,subs="attributes+"]
+----
+quickstart/
+├─ plugins/
+│  ├─ neo4j-kafka-connect-{exact-connector-version}.jar
+├─ docker-compose.yml
+----
+
+[source,bash]
+----
+docker compose up -d
+docker compose ps
+----
+
+Wait until every service reports healthy — 90-120 seconds on a first run.
+Then confirm the plugin loaded:
+
+[source,bash]
+----
+curl -s http://localhost:8083/connector-plugins | grep -o 'sink.Neo4jConnector'
+----
+
+You can log in to Neo4j Browser at \http://localhost:7474 with `neo4j` / `password`.
+
+[TIP]
+The CUD strategy does not require Change Data Capture, so there is nothing to enable on the
+database.
+
+== Step 1: Create the topic
+
+[source,bash]
+----
+docker compose exec broker kafka-topics \
+  --bootstrap-server broker:29092 \
+  --create --topic crm --partitions 1 --replication-factor 1
+----
+
+== Step 2: Create the sink connector
+
+Save the following as `sink.cud.neo4j.json`:
+
+ifdef::backend-pdf[]
+.quickstart.sink.cud.json-raw.json
+endif::[]
+[source,json]
+----
+include::example$docker-data/quickstart.sink.cud.json-raw.json[]
+----
+
+Two settings name the same topic, and both are required:
+
+* `topics` — the Kafka Connect subscription, telling the worker which topics to consume.
+* `neo4j.cud.topics` — telling the connector to interpret those topics as CUD messages.
+
+A topic listed in `topics` but missing from `neo4j.cud.topics` is consumed and silently ignored.
+
+Register the connector:
+
+[source,bash]
+----
+curl -X POST http://localhost:8083/connectors \
+  -H 'Content-Type:application/json' \
+  -H 'Accept:application/json' \
+  -d @sink.cud.neo4j.json
+----
+
+[source,bash]
+----
+curl -s http://localhost:8083/connectors/Neo4jSinkCudQuickstart/status
+----
+
+Both the connector and its task should report `RUNNING`.
+
+== The CUD message format
+
+Every message is a JSON object. `type` and `op` are always required; the rest depends on them.
+
+.Node messages
+[cols="1,1,3",opts=header]
+|===
+| Field | Required | Meaning
+
+| `type` | yes | `node`
+| `op` | yes | `create`, `update`, `merge` or `delete`
+| `labels` | no | labels to apply, as an array
+| `properties` | except for `delete` | the properties to set
+| `ids` | except for `create` | the lookup key, as an object
+| `detach` | no | on `delete`, also remove attached relationships. Defaults to `false`
+|===
+
+.Relationship messages
+[cols="1,1,3",opts=header]
+|===
+| Field | Required | Meaning
+
+| `type` | yes | `relationship`
+| `op` | yes | `create`, `update`, `merge` or `delete`
+| `rel_type` | yes | the relationship type
+| `from` / `to` | yes | endpoint objects, each with `labels`, `ids` and an optional `op`
+| `properties` | no | the properties to set on the relationship
+| `ids` | no | lookup key for the relationship itself
+|===
+
+`op` and `type` are case-insensitive. Inside `from` and `to`, `op` accepts only `match` (the
+default) or `merge` — it decides whether a missing endpoint is created.
+
+[IMPORTANT]
+====
+`kafka-console-producer` reads **one message per line**, so each CUD object must be on a single
+line when produced this way.
+The examples in xref:sink/cud.adoc[CUD File Format Strategy] are pretty-printed for readability;
+the commands below are the same objects flattened.
+====
+
+== Step 3: Create nodes
+
+[source,bash]
+----
+docker compose exec -T broker kafka-console-producer \
+  --bootstrap-server broker:29092 \
+  --topic crm <<'EOF'
+{"type":"node","op":"create","labels":["Customer"],"properties":{"id":1,"name":"John Doe","tier":"standard"}}
+{"type":"node","op":"create","labels":["Customer"],"properties":{"id":2,"name":"Mary Smith","tier":"standard"}}
+{"type":"node","op":"create","labels":["Product"],"properties":{"id":100,"name":"Laptop"}}
+EOF
+----
+
+Each of these becomes `CREATE (n:Customer) SET n = $properties`.
+
+Verify in Neo4j Browser at \http://localhost:7474/browser/:
+
+[source,cypher]
+----
+MATCH (n) RETURN labels(n) AS labels, n.id AS id, n.name AS name ORDER BY id
+----
+
+== Step 4: Create a relationship
+
+The endpoints are looked up by their `ids`, so they must already exist:
+
+[source,bash]
+----
+docker compose exec -T broker kafka-console-producer \
+  --bootstrap-server broker:29092 \
+  --topic crm <<'EOF'
+{"type":"relationship","op":"create","rel_type":"PURCHASED","from":{"labels":["Customer"],"ids":{"id":1}},"to":{"labels":["Product"],"ids":{"id":100}},"properties":{"price":999.99,"currency":"USD"}}
+EOF
+----
+
+This becomes:
+
+[source,cypher]
+----
+MATCH (start:Customer {id: $from.ids.id}) WITH start
+MATCH (end:Product {id: $to.ids.id}) WITH start, end
+CREATE (start)-[r:PURCHASED]->(end)
+SET r = $properties
+----
+
+Because both endpoints default to `match`, a missing endpoint means the `MATCH` finds nothing and
+**no relationship is created — without an error**. To create endpoints on demand, set `op` on them:
+
+[source,bash]
+----
+docker compose exec -T broker kafka-console-producer \
+  --bootstrap-server broker:29092 \
+  --topic crm <<'EOF'
+{"type":"relationship","op":"create","rel_type":"PURCHASED","from":{"labels":["Customer"],"ids":{"id":2},"op":"merge"},"to":{"labels":["Product"],"ids":{"id":200},"op":"merge"},"properties":{"price":49.99,"currency":"USD"}}
+EOF
+----
+
+Product `200` did not exist and is created by the `merge`.
+
+[source,cypher]
+----
+MATCH (c:Customer)-[r:PURCHASED]->(p:Product)
+RETURN c.name AS customer, p.id AS product, r.price AS price ORDER BY customer
+----
+
+== Step 5: Update and merge
+
+`update` sets properties on an existing node, leaving others intact (`SET n += $properties`):
+
+[source,bash]
+----
+docker compose exec -T broker kafka-console-producer \
+  --bootstrap-server broker:29092 \
+  --topic crm <<'EOF'
+{"type":"node","op":"update","labels":["Customer"],"ids":{"id":1},"properties":{"tier":"gold"}}
+EOF
+----
+
+Customer 1's `tier` becomes `gold` and `name` is untouched.
+
+`merge` creates the node if the `ids` do not match anything, and updates it if they do:
+
+[source,bash]
+----
+docker compose exec -T broker kafka-console-producer \
+  --bootstrap-server broker:29092 \
+  --topic crm <<'EOF'
+{"type":"node","op":"merge","labels":["Customer"],"ids":{"id":3},"properties":{"name":"Ann Bolin","tier":"standard"}}
+{"type":"node","op":"merge","labels":["Customer"],"ids":{"id":3},"properties":{"tier":"gold"}}
+EOF
+----
+
+Customer 3 is created by the first message and updated by the second — one node, not two.
+
+[source,cypher]
+----
+MATCH (c:Customer) RETURN c.id AS id, c.name AS name, c.tier AS tier ORDER BY id
+----
+
+== Step 6: Delete
+
+A `delete` needs only `ids`. Deleting a node that still has relationships fails unless you ask for
+a detach delete:
+
+[source,bash]
+----
+docker compose exec -T broker kafka-console-producer \
+  --bootstrap-server broker:29092 \
+  --topic crm <<'EOF'
+{"type":"node","op":"delete","labels":["Customer"],"ids":{"id":3}}
+{"type":"node","op":"delete","labels":["Customer"],"ids":{"id":2},"detach":true}
+EOF
+----
+
+Customer 3 has no relationships, so a plain delete works. Customer 2 bought product 200, so it
+needs `"detach": true`.
+
+[source,cypher]
+----
+MATCH (c:Customer) RETURN c.id AS id, c.name AS name ORDER BY id
+----
+
+Only customer 1 is left, confirming both deletes applied.
+
+[NOTE]
+`delete` is for individual entities identified by `ids`. It is not a way to run arbitrary
+Cypher deletes from JSON.
+
+[[other-formats]]
+== Using Avro, Protobuf or JSON Schema
+
+The CUD format is unchanged across serialization formats; only the converters differ:
+
+[source,json]
+----
+  "value.converter": "io.confluent.connect.avro.AvroConverter",
+  "value.converter.schema.registry.url": "http://schema-registry:8081"
+----
+
+You then need a schema-aware producer such as `kafka-avro-console-producer`.
+Note that CUD messages are deeply nested and loosely typed by nature, which makes them awkward to
+express as a strict Avro or Protobuf schema — plain JSON is often the more natural fit for this
+strategy.
+See xref:sink/connect-types.adoc[Type support].
+
+== Troubleshooting
+
+[source,bash]
+----
+curl -s http://localhost:8083/connectors/Neo4jSinkCudQuickstart/status
+docker compose logs connect
+----
+
+`Message value must be convertible to a Map`:: The message was not a JSON object — check for a
+stray blank line or a pretty-printed object split across several lines, since
+`kafka-console-producer` treats each line as its own message.
+`Failed to transform message`:: The object parsed but is not a valid operation. Check that `type`
+is `node` or `relationship`, that `op` is one of `create`, `update`, `merge`, `delete`, and that
+`ids` is present for everything except `create`.
+Relationship silently not created:: The endpoints default to `op: match`. Either create the
+endpoint nodes first, or set `"op": "merge"` inside `from` and `to`.
+Delete appears to do nothing:: `ids` did not match any entity. Confirm the property name and the
+value type — `{"id": 1}` and `{"id": "1"}` are different lookups.
+Task fails on a node delete:: The node still has relationships. Add `"detach": true`.
+Nothing happens at all:: The topic is in `topics` but missing from `neo4j.cud.topics`.
+
+== Next steps
+
+* xref:sink/cud.adoc[CUD File Format Strategy] — every field, every operation, and the exact
+  Cypher each one generates, including `_id` and `_elementId` lookups.
+* xref:sink/configuration.adoc[Sink settings] — batching, retries and connection options.
+* xref:sink/error-handling.adoc[Error handling] — dead letter queues, useful here since a
+  malformed operation is a per-message failure.
+* xref:sink/monitoring.adoc[Monitoring] — JMX metrics exposed by the sink connector.

--- a/modules/ROOT/pages/quickstart/sink-cud.adoc
+++ b/modules/ROOT/pages/quickstart/sink-cud.adoc
@@ -21,15 +21,6 @@ Pick it when:
 * one topic must carry operations on several different labels and relationship types;
 * you want a single stream to drive a full entity lifecycle.
 
-Consider a different strategy if:
-
-xref:sink/pattern.adoc[Pattern]:: Every message is an upsert of the same shape. Patterns are much
-less verbose when the operation never varies.
-xref:sink/cypher.adoc[Cypher]:: You need derived values or logic the CUD format cannot express.
-CUD is a fixed vocabulary, not a query language.
-xref:sink/cdc.adoc[Change Data Capture]:: Your messages came from a Neo4j source connector or
-Neo4j Streams. CDC already encodes operations in its own format.
-
 [TIP]
 Unlike xref:sink/pattern.adoc[Pattern], CUD has no one-mapping-per-topic restriction — a single
 topic can carry nodes and relationships of any label. This guide uses one topic for everything.
@@ -62,10 +53,6 @@ See <<other-formats>> for Avro, Protobuf and JSON Schema.
 === Start the environment
 
 include::partial$quickstart-environment.adoc[]
-
-[TIP]
-The CUD strategy does not require Change Data Capture, so there is nothing to enable on the
-database.
 
 == Step 1: Create the topic
 

--- a/modules/ROOT/pages/quickstart/sink-cypher.adoc
+++ b/modules/ROOT/pages/quickstart/sink-cypher.adoc
@@ -53,41 +53,7 @@ See <<other-formats>> for Avro, Protobuf and JSON Schema.
 
 === Start the environment
 
-Copy the following Docker Compose file into a new directory.
-
-.docker-compose.yml
-[source,yaml]
-----
-include::example$docker-data/docker-compose.yml[]
-----
-
-Copy the {product-name} JAR into a directory named `plugins` next to your `docker-compose.yml`,
-so that the directory looks like this:
-
-[source,text,subs="attributes+"]
-----
-quickstart/
-├─ plugins/
-│  ├─ neo4j-kafka-connect-{exact-connector-version}.jar
-├─ docker-compose.yml
-----
-
-Start the stack:
-
-[source,bash]
-----
-docker compose up -d
-----
-
-Wait until every service reports as healthy — this takes 90-120 seconds on a first run:
-
-[source,bash]
-----
-docker compose ps
-----
-
-You can now log in to Neo4j Browser at \http://localhost:7474 with the username `neo4j` and the
-password `password`.
+include::partial$quickstart-environment.adoc[]
 
 [TIP]
 The Cypher strategy does not require Change Data Capture, so there is nothing to enable on the

--- a/modules/ROOT/pages/quickstart/sink-cypher.adoc
+++ b/modules/ROOT/pages/quickstart/sink-cypher.adoc
@@ -20,15 +20,6 @@ Pick it when you need to:
 * write conditional logic, run multiple `MERGE` clauses, or touch several labels per message;
 * map one message onto a subgraph whose shape does not follow directly from the message fields.
 
-Consider a different strategy if:
-
-xref:sink/pattern.adoc[Pattern]:: Your messages map field-for-field onto nodes and relationships,
-and you would rather declare that mapping than write Cypher.
-xref:sink/cud.adoc[CUD]:: Your producer already emits explicit create, update and delete
-instructions.
-xref:sink/cdc.adoc[Change Data Capture]:: Your messages were produced by a Neo4j source connector
-or Neo4j Streams, and you are replicating one Neo4j database into another.
-
 == What you will build
 
 A single sink connector that consumes JSON messages from a topic named `people`, and for each

--- a/modules/ROOT/pages/quickstart/sink-cypher.adoc
+++ b/modules/ROOT/pages/quickstart/sink-cypher.adoc
@@ -1,0 +1,255 @@
+= Quickstart: Sink with Cypher
+:xrefstyle: full
+
+ifdef::env-docs[]
+[abstract]
+--
+Load messages from a Kafka topic into Neo4j using your own Cypher query.
+--
+endif::env-docs[]
+
+== When to use the Cypher strategy
+
+Use the xref:sink/cypher.adoc[Cypher strategy] when you consume messages from a Kafka topic and
+want **full control** over the write query that applies them to Neo4j.
+Each message is passed to a Cypher statement you provide, as a parameter.
+
+Pick it when you need to:
+
+* compute or derive property values, rather than copy fields verbatim;
+* write conditional logic, run multiple `MERGE` clauses, or touch several labels per message;
+* map one message onto a subgraph whose shape does not follow directly from the message fields.
+
+Consider a different strategy if:
+
+xref:sink/pattern.adoc[Pattern]:: Your messages map field-for-field onto nodes and relationships,
+and you would rather declare that mapping than write Cypher.
+xref:sink/cud.adoc[CUD]:: Your producer already emits explicit create, update and delete
+instructions.
+xref:sink/cdc.adoc[Change Data Capture]:: Your messages were produced by a Neo4j source connector
+or Neo4j Streams, and you are replicating one Neo4j database into another.
+
+== What you will build
+
+A single sink connector that consumes JSON messages from a topic named `people`, and for each
+message merges a `Person` node, a `City` node and a `LIVES_IN` relationship between them.
+
+[source,text]
+----
+people topic ──> Sink connector ──> (:Person)-[:LIVES_IN]->(:City)
+----
+
+This guide does not use a source connector — messages are produced by hand, the way an external
+system would produce them.
+
+[NOTE]
+This guide uses plain JSON messages, so no Schema Registry is required.
+See <<other-formats>> for Avro, Protobuf and JSON Schema.
+
+== Prerequisites
+
+* Docker Compose v2.20.3 or later.
+* The {product-name} archive, unpacked as described in xref:installation.adoc[].
+
+=== Start the environment
+
+Copy the following Docker Compose file into a new directory.
+
+.docker-compose.yml
+[source,yaml]
+----
+include::example$docker-data/docker-compose.yml[]
+----
+
+Copy the {product-name} JAR into a directory named `plugins` next to your `docker-compose.yml`,
+so that the directory looks like this:
+
+[source,text,subs="attributes+"]
+----
+quickstart/
+├─ plugins/
+│  ├─ neo4j-kafka-connect-{exact-connector-version}.jar
+├─ docker-compose.yml
+----
+
+Start the stack:
+
+[source,bash]
+----
+docker compose up -d
+----
+
+Wait until every service reports as healthy — this takes 90-120 seconds on a first run:
+
+[source,bash]
+----
+docker compose ps
+----
+
+You can now log in to Neo4j Browser at \http://localhost:7474 with the username `neo4j` and the
+password `password`.
+
+[TIP]
+The Cypher strategy does not require Change Data Capture, so there is nothing to enable on the
+database.
+
+== Step 1: Create the topic
+
+[source,bash]
+----
+docker compose exec broker kafka-topics \
+  --bootstrap-server broker:29092 \
+  --create --topic people --partitions 1 --replication-factor 1
+----
+
+== Step 2: Create the sink connector
+
+Save the following as `sink.cypher.neo4j.json`:
+
+ifdef::backend-pdf[]
+.quickstart.sink.cypher.json-raw.json
+endif::[]
+[source,json]
+----
+include::example$docker-data/quickstart.sink.cypher.json-raw.json[]
+----
+
+The `neo4j.cypher.topic.people` setting is the whole strategy: it names the topic
+(`neo4j.cypher.topic.<topic>`) and gives the Cypher statement to run for its messages.
+Written out, that statement is:
+
+[source,cypher]
+----
+WITH __value AS person
+MERGE (p:Person {name: person.name, surname: person.surname})
+SET p.fullName = person.name + ' ' + person.surname
+MERGE (c:City {name: person.city})
+MERGE (p)-[:LIVES_IN]->(c)
+----
+
+`+__value+` is the message value, bound automatically for every message.
+The header, key and timestamp are available as `+__header+`, `+__key+` and `+__timestamp+`.
+See xref:sink/configuration.adoc#cypher_strategy_settings[Cypher strategy settings] to rename
+these.
+
+Note the `SET p.fullName = ...` clause — deriving a value like this is the kind of thing that
+makes Cypher the right strategy rather than xref:sink/pattern.adoc[Pattern].
+
+Register the connector:
+
+[source,bash]
+----
+curl -X POST http://localhost:8083/connectors \
+  -H 'Content-Type:application/json' \
+  -H 'Accept:application/json' \
+  -d @sink.cypher.neo4j.json
+----
+
+Confirm it is running:
+
+[source,bash]
+----
+curl -s http://localhost:8083/connectors/Neo4jSinkCypherQuickstart/status
+----
+
+Both the connector and its task should report `RUNNING`.
+
+== Step 3: Produce messages
+
+Create the connector before producing, so that no message is missed.
+
+[source,bash]
+----
+docker compose exec -T broker kafka-console-producer \
+  --bootstrap-server broker:29092 \
+  --topic people <<'EOF'
+{"name": "Jane", "surname": "Doe", "city": "London"}
+{"name": "John", "surname": "Doe", "city": "London"}
+{"name": "Mary", "surname": "Smith", "city": "Berlin"}
+EOF
+----
+
+== Step 4: Verify the result
+
+In Neo4j Browser at \http://localhost:7474/browser/, run:
+
+[source,cypher]
+----
+MATCH (p:Person)-[:LIVES_IN]->(c:City) RETURN p.fullName AS person, c.name AS city ORDER BY person
+----
+
+You should get three rows, and two `City` nodes — `Jane` and `John` both merged onto the same
+`London` node:
+
+[source,text]
+----
+person       city
+"Jane Doe"   "London"
+"John Doe"   "London"
+"Mary Smith" "Berlin"
+----
+
+Produce another message to see it applied:
+
+[source,bash]
+----
+docker compose exec -T broker kafka-console-producer \
+  --bootstrap-server broker:29092 \
+  --topic people <<'EOF'
+{"name": "Ann", "surname": "Bolin", "city": "Berlin"}
+EOF
+----
+
+Re-run the query — `Ann Bolin` is added and attached to the existing `Berlin` node.
+
+[[other-formats]]
+== Using Avro, Protobuf or JSON Schema
+
+The strategy is identical for schema-carrying formats; only the converters change.
+Replace the `value.converter` lines in the connector configuration with one of the following and
+point them at the Schema Registry included in the Compose stack:
+
+[source,json]
+----
+  "value.converter": "io.confluent.connect.avro.AvroConverter",
+  "value.converter.schema.registry.url": "http://schema-registry:8081"
+----
+
+You then need a schema-aware producer, such as `kafka-avro-console-producer`, in place of
+`kafka-console-producer`.
+See xref:sink/cypher.adoc[Cypher strategy] for configuration examples in each format, and
+xref:sink/connect-types.adoc[Type support] for how Kafka Connect types map onto Neo4j types.
+
+== Troubleshooting
+
+Check the connector status first — a failed task reports its exception here:
+
+[source,bash]
+----
+curl -s http://localhost:8083/connectors/Neo4jSinkCypherQuickstart/status
+----
+
+Then check the worker log:
+
+[source,bash]
+----
+docker compose logs connect
+----
+
+No nodes created:: Confirm the topic name in `topics` matches the suffix of
+`neo4j.cypher.topic.<topic>`. A mismatch means the connector consumes the topic but has no
+statement for it.
+Task failed with a Cypher error:: The statement is executed as written. Test it in Neo4j Browser
+with a sample parameter before configuring it.
+Messages produced before the connector existed:: Sink connectors start from the earliest
+available offset by default, but if you have already consumed them, produce them again.
+
+To route failing messages to a dead letter queue instead of stopping the task, see
+xref:sink/error-handling.adoc[Error handling].
+
+== Next steps
+
+* xref:sink/cypher.adoc[Cypher strategy] — full reference, including `+__key+` and `+__header+` binding.
+* xref:sink/configuration.adoc[Sink settings] — batching, retries and connection options.
+* xref:sink/error-handling.adoc[Error handling] — dead letter queues and error tolerance.
+* xref:sink/monitoring.adoc[Monitoring] — JMX metrics exposed by the sink connector.

--- a/modules/ROOT/pages/quickstart/sink-pattern.adoc
+++ b/modules/ROOT/pages/quickstart/sink-pattern.adoc
@@ -61,39 +61,7 @@ See <<other-formats>> for Avro, Protobuf and JSON Schema.
 
 === Start the environment
 
-Copy the following Docker Compose file into a new directory.
-
-.docker-compose.yml
-[source,yaml]
-----
-include::example$docker-data/docker-compose.yml[]
-----
-
-Copy the {product-name} JAR into a directory named `plugins` next to your `docker-compose.yml`:
-
-[source,text,subs="attributes+"]
-----
-quickstart/
-├─ plugins/
-│  ├─ neo4j-kafka-connect-{exact-connector-version}.jar
-├─ docker-compose.yml
-----
-
-[source,bash]
-----
-docker compose up -d
-docker compose ps
-----
-
-Wait until every service reports healthy — 90-120 seconds on a first run.
-Then confirm the plugin loaded:
-
-[source,bash]
-----
-curl -s http://localhost:8083/connector-plugins | grep -o 'sink.Neo4jConnector'
-----
-
-You can log in to Neo4j Browser at \http://localhost:7474 with `neo4j` / `password`.
+include::partial$quickstart-environment.adoc[]
 
 [TIP]
 The Pattern strategy does not require Change Data Capture, so there is nothing to enable on the

--- a/modules/ROOT/pages/quickstart/sink-pattern.adoc
+++ b/modules/ROOT/pages/quickstart/sink-pattern.adoc
@@ -266,7 +266,9 @@ Confirm the merge behaviour — two users, two products, three relationships:
 
 [source,cypher]
 ----
-MATCH (n) RETURN labels(n) AS label, count(*) AS count
+MATCH (n) RETURN labels(n) AS item, count(*) AS count
+UNION ALL
+MATCH ()-[r]->() RETURN [type(r)] AS item, count(*) AS count
 ----
 
 Now re-send one of the purchase messages:

--- a/modules/ROOT/pages/quickstart/sink-pattern.adoc
+++ b/modules/ROOT/pages/quickstart/sink-pattern.adoc
@@ -1,0 +1,343 @@
+= Quickstart: Sink with Pattern
+:xrefstyle: full
+
+ifdef::env-docs[]
+[abstract]
+--
+Map Kafka messages onto nodes and relationships declaratively, without writing Cypher.
+--
+endif::env-docs[]
+
+== When to use the Pattern strategy
+
+Use the xref:sink/pattern.adoc[Pattern strategy] when your messages map onto graph elements
+field-for-field, and you would rather **declare** that mapping than write a query.
+You give a Cypher-like pattern per topic; the connector generates the `MERGE` for you.
+
+Pick it when:
+
+* each message describes one node, or one relationship with its two endpoints;
+* the properties you want are already fields on the message, possibly renamed or nested;
+* you want key-based upserts without hand-writing `MERGE` clauses.
+
+Consider a different strategy if:
+
+xref:sink/cypher.adoc[Cypher]:: You need derived values, conditional logic, or more than one
+graph element per message. Patterns cannot compute — they only map.
+xref:sink/cud.adoc[CUD]:: Your producer already emits explicit create, update and delete
+instructions.
+xref:sink/cdc.adoc[Change Data Capture]:: Your messages came from a Neo4j source connector or
+Neo4j Streams.
+
+[IMPORTANT]
+One topic carries exactly one pattern.
+You cannot extract two node types, or a node *and* a relationship, from the same topic — use a
+separate topic per pattern.
+This guide therefore uses two topics.
+
+== What you will build
+
+Two connectors' worth of mapping in a single connector instance: a node pattern on one topic and
+a relationship pattern on another.
+
+[source,text]
+----
+users topic     ──>  (:User {userId, name, surname})
+
+purchases topic ──>  (:User {userId})-[:BOUGHT {price, currency}]->(:Product {productId, name})
+----
+
+No source connector is involved — messages are produced by hand, the way an external system
+would produce them.
+
+[NOTE]
+This guide uses plain JSON messages, so no Schema Registry is required.
+See <<other-formats>> for Avro, Protobuf and JSON Schema.
+
+== Prerequisites
+
+* Docker Compose v2.20.3 or later.
+* The {product-name} archive, unpacked as described in xref:installation.adoc[].
+
+=== Start the environment
+
+Copy the following Docker Compose file into a new directory.
+
+.docker-compose.yml
+[source,yaml]
+----
+include::example$docker-data/docker-compose.yml[]
+----
+
+Copy the {product-name} JAR into a directory named `plugins` next to your `docker-compose.yml`:
+
+[source,text,subs="attributes+"]
+----
+quickstart/
+├─ plugins/
+│  ├─ neo4j-kafka-connect-{exact-connector-version}.jar
+├─ docker-compose.yml
+----
+
+[source,bash]
+----
+docker compose up -d
+docker compose ps
+----
+
+Wait until every service reports healthy — 90-120 seconds on a first run.
+Then confirm the plugin loaded:
+
+[source,bash]
+----
+curl -s http://localhost:8083/connector-plugins | grep -o 'sink.Neo4jConnector'
+----
+
+You can log in to Neo4j Browser at \http://localhost:7474 with `neo4j` / `password`.
+
+[TIP]
+The Pattern strategy does not require Change Data Capture, so there is nothing to enable on the
+database.
+
+== Step 1: Create key constraints
+
+Patterns upsert on their key properties — the fields marked with `!`.
+Create a matching node key constraint for each, in Neo4j Browser:
+
+[source,cypher]
+----
+CREATE CONSTRAINT user_id IF NOT EXISTS FOR (u:User) REQUIRE u.userId IS NODE KEY;
+CREATE CONSTRAINT product_id IF NOT EXISTS FOR (p:Product) REQUIRE p.productId IS NODE KEY;
+----
+
+This step is optional but recommended.
+Without it the connector still works, but it logs a warning per pattern —
+`Label 'User' does not match the key(s) defined by the pattern ...` — and every upsert falls back
+to an unindexed scan.
+
+[NOTE]
+Node key constraints require Neo4j Enterprise Edition or Aura.
+On Community Edition, use `REQUIRE u.userId IS UNIQUE` instead.
+
+== Step 2: Create the topics
+
+One topic per pattern:
+
+[source,bash]
+----
+docker compose exec broker kafka-topics \
+  --bootstrap-server broker:29092 \
+  --create --topic users --partitions 1 --replication-factor 1
+
+docker compose exec broker kafka-topics \
+  --bootstrap-server broker:29092 \
+  --create --topic purchases --partitions 1 --replication-factor 1
+----
+
+== Step 3: Create the sink connector
+
+Save the following as `sink.pattern.neo4j.json`:
+
+ifdef::backend-pdf[]
+.quickstart.sink.pattern.json-raw.json
+endif::[]
+[source,json]
+----
+include::example$docker-data/quickstart.sink.pattern.json-raw.json[]
+----
+
+Register it:
+
+[source,bash]
+----
+curl -X POST http://localhost:8083/connectors \
+  -H 'Content-Type:application/json' \
+  -H 'Accept:application/json' \
+  -d @sink.pattern.neo4j.json
+----
+
+Confirm it is running:
+
+[source,bash]
+----
+curl -s http://localhost:8083/connectors/Neo4jSinkPatternQuickstart/status
+----
+
+Both the connector and its task should report `RUNNING`.
+
+=== Reading the two patterns
+
+The node pattern on the `users` topic:
+
+[source]
+----
+(:User{!userId, name, surname})
+----
+
+* `:User` — the label to merge on.
+* `!userId` — a **key** property. `MERGE` matches on it, so re-sending the same `userId` updates
+  the existing node rather than creating a second one. At least one key property is required.
+* `name, surname` — the only other properties copied onto the node. Any other field in the
+  message is ignored.
+
+The relationship pattern on the `purchases` topic:
+
+[source]
+----
+(:User{!userId})-[:BOUGHT{price, currency}]->(:Product{!productId, name: productName})
+----
+
+* both endpoints are merged on their key properties, then `:BOUGHT` is merged between them;
+* `{price, currency}` are copied onto the relationship;
+* `name: productName` renames a message field on the way in — the `productName` field becomes the
+  `name` property on `:Product`.
+
+Two shorthands worth knowing: `{!userId, *}` (or just `{!userId}`) copies **all** message fields,
+and `{!userId, -address}` copies all **except** `address`. You cannot mix inclusion and exclusion
+in one pattern. Full syntax is in xref:sink/pattern.adoc[Pattern strategy].
+
+[IMPORTANT]
+====
+Note `"neo4j.pattern.merge-node-properties": true` in the configuration.
+It is required here, and this is the setting most likely to surprise you.
+
+Both topics write to the same `:User` nodes. On a relationship pattern, an endpoint like
+`(:User{!userId})` contributes no value properties — wildcards are not allowed on endpoints — so
+with the default `false` the connector issues the equivalent of `SET u = {}` before re-applying the
+key. That **erases** the `name` and `surname` written by the `users` topic, and the node is left
+holding only `userId`.
+
+Set it to `true` and the connector uses `SET u += ...` instead, leaving properties written by other
+topics intact.
+As a rule: whenever more than one topic writes to the same node, you want this enabled.
+`neo4j.pattern.merge-relationship-properties` does the same for relationship properties.
+====
+
+== Step 4: Produce messages
+
+Create the connector before producing, so nothing is missed.
+Users first:
+
+[source,bash]
+----
+docker compose exec -T broker kafka-console-producer \
+  --bootstrap-server broker:29092 \
+  --topic users <<'EOF'
+{"userId": 1, "name": "John", "surname": "Doe"}
+{"userId": 2, "name": "Mary", "surname": "Smith"}
+EOF
+----
+
+Then purchases:
+
+[source,bash]
+----
+docker compose exec -T broker kafka-console-producer \
+  --bootstrap-server broker:29092 \
+  --topic purchases <<'EOF'
+{"userId": 1, "productId": 100, "productName": "Laptop", "price": 999.99, "currency": "USD"}
+{"userId": 2, "productId": 100, "productName": "Laptop", "price": 949.00, "currency": "USD"}
+{"userId": 2, "productId": 200, "productName": "Keyboard", "price": 49.99, "currency": "USD"}
+EOF
+----
+
+Note that `productId: 100` appears twice.
+Because `productId` is a key property, both messages merge onto the *same* `:Product` node.
+
+== Step 5: Verify the result
+
+In Neo4j Browser at \http://localhost:7474/browser/:
+
+[source,cypher]
+----
+MATCH (u:User)-[b:BOUGHT]->(p:Product)
+RETURN u.name AS user, p.name AS product, b.price AS price ORDER BY user, product
+----
+
+[source,text]
+----
+user     product      price
+"John"   "Laptop"     999.99
+"Mary"   "Keyboard"   49.99
+"Mary"   "Laptop"     949.0
+----
+
+Confirm the merge behaviour — two users, two products, three relationships:
+
+[source,cypher]
+----
+MATCH (n) RETURN labels(n) AS label, count(*) AS count
+----
+
+Now re-send one of the purchase messages:
+
+[source,bash]
+----
+docker compose exec -T broker kafka-console-producer \
+  --bootstrap-server broker:29092 \
+  --topic purchases <<'EOF'
+{"userId": 1, "productId": 100, "productName": "Laptop", "price": 899.00, "currency": "USD"}
+EOF
+----
+
+Re-run the first query. John's `:BOUGHT` price is updated to `899.0` and **no** new node or
+relationship is created — that is the key properties doing their work.
+
+== Deleting with tombstones
+
+The Pattern strategy also handles
+https://en.wikipedia.org/wiki/Tombstone_(data_store)[tombstone records]: a message whose key
+carries the pattern's key properties and whose value is `null` deletes the matching element.
+This needs a producer that can emit a null value and a structured key, so it is not shown here —
+see xref:sink/pattern.adoc#_tombstone_records[Tombstone records].
+
+[[other-formats]]
+== Using Avro, Protobuf or JSON Schema
+
+Patterns are unchanged across formats; only the converters differ.
+Replace the `value.converter` lines with, for example:
+
+[source,json]
+----
+  "value.converter": "io.confluent.connect.avro.AvroConverter",
+  "value.converter.schema.registry.url": "http://schema-registry:8081"
+----
+
+You then need a schema-aware producer such as `kafka-avro-console-producer`.
+Schema-carrying formats also preserve Kafka Connect logical types — with plain JSON, a date
+arrives as a string, whereas Avro and Protobuf map it onto a Neo4j temporal type.
+See xref:sink/connect-types.adoc[Type support].
+
+== Troubleshooting
+
+[source,bash]
+----
+curl -s http://localhost:8083/connectors/Neo4jSinkPatternQuickstart/status
+docker compose logs connect
+----
+
+`Message value must be convertible to a Map`:: The Pattern strategy requires an object-shaped
+message value. A bare scalar or array will not work — unlike the Cypher strategy, which can bind
+any value.
+Task fails with a pattern parse error:: The pattern is validated at startup. Check that every
+node pattern has at least one `!` key property, and that inclusion and exclusion properties are
+not mixed.
+`Label 'X' does not match the key(s) defined by the pattern`:: A warning, not an error. Create the
+node key constraint from <<_step_1_create_key_constraints,Step 1>>.
+Nodes created but properties missing:: The pattern lists properties explicitly. A field absent
+from the pattern is not copied — use `{!key, *}` to copy everything.
+A node's properties vanish after a second topic writes to it:: `neo4j.pattern.merge-node-properties`
+defaults to `false`, which makes the connector *replace* a node's whole property map rather than
+add to it. A relationship endpoint contributes no value properties, so it replaces them with
+nothing. Set the option to `true`. Diagnose it with
+`MATCH (n:User) RETURN n.userId, keys(n)` — you will see only the key property left.
+Nothing at all happens:: Confirm each topic in `topics` has a matching
+`neo4j.pattern.topic.<topic>` entry. A topic with no pattern is consumed and silently ignored.
+
+== Next steps
+
+* xref:sink/pattern.adoc[Pattern strategy] — full pattern grammar, tombstones, batching and
+  exactly-once semantics.
+* xref:sink/configuration.adoc[Sink settings] — `neo4j.pattern.bind-*`, batching, retries.
+* xref:sink/error-handling.adoc[Error handling] — dead letter queues and error tolerance.
+* xref:sink/monitoring.adoc[Monitoring] — JMX metrics exposed by the sink connector.

--- a/modules/ROOT/pages/quickstart/sink-pattern.adoc
+++ b/modules/ROOT/pages/quickstart/sink-pattern.adoc
@@ -20,15 +20,6 @@ Pick it when:
 * the properties you want are already fields on the message, possibly renamed or nested;
 * you want key-based upserts without hand-writing `MERGE` clauses.
 
-Consider a different strategy if:
-
-xref:sink/cypher.adoc[Cypher]:: You need derived values, conditional logic, or more than one
-graph element per message. Patterns cannot compute — they only map.
-xref:sink/cud.adoc[CUD]:: Your producer already emits explicit create, update and delete
-instructions.
-xref:sink/cdc.adoc[Change Data Capture]:: Your messages came from a Neo4j source connector or
-Neo4j Streams.
-
 [IMPORTANT]
 One topic carries exactly one pattern.
 You cannot extract two node types, or a node *and* a relationship, from the same topic — use a

--- a/modules/ROOT/pages/quickstart/source-cdc.adoc
+++ b/modules/ROOT/pages/quickstart/source-cdc.adoc
@@ -21,12 +21,6 @@ Pick it when:
 * you do not want to add tracking properties to your data;
 * you need before-and-after state for updates.
 
-Consider the other source strategy if:
-
-xref:source/query.adoc[Query]:: You only want a specific slice of the graph, you are on Community
-Edition, or you cannot enable CDC. See xref:quickstart/source-query.adoc[Quickstart: Source with
-Query].
-
 [NOTE]
 ====
 Sending these events into **another Neo4j database** is a separate exercise, because the sink side

--- a/modules/ROOT/pages/quickstart/source-cdc.adoc
+++ b/modules/ROOT/pages/quickstart/source-cdc.adoc
@@ -57,31 +57,7 @@ equally valid. Splitting them makes the event shapes easier to compare.
 
 === Start the environment
 
-Copy the following Docker Compose file into a new directory.
-
-.docker-compose.yml
-[source,yaml]
-----
-include::example$docker-data/docker-compose.yml[]
-----
-
-Copy the {product-name} JAR into a directory named `plugins` next to your `docker-compose.yml`:
-
-[source,text,subs="attributes+"]
-----
-quickstart/
-├─ plugins/
-│  ├─ neo4j-kafka-connect-{exact-connector-version}.jar
-├─ docker-compose.yml
-----
-
-[source,bash]
-----
-docker compose up -d
-docker compose ps
-----
-
-Wait until every service reports healthy — 90-120 seconds on a first run.
+include::partial$quickstart-environment.adoc[]
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/quickstart/source-cdc.adoc
+++ b/modules/ROOT/pages/quickstart/source-cdc.adoc
@@ -1,0 +1,331 @@
+= Quickstart: Source with Change Data Capture
+:xrefstyle: full
+
+ifdef::env-docs[]
+[abstract]
+--
+Publish every change in a Neo4j database to Kafka topics, in real time.
+--
+endif::env-docs[]
+
+== When to use the CDC strategy
+
+Use the xref:source/cdc.adoc[Change Data Capture strategy] when you want Kafka to receive
+**every** change to the data you care about — creates, updates and deletes — as it happens, without
+modifying your graph model to support it.
+
+Pick it when:
+
+* you need deletes. This is the big one: a polling query cannot see a node that is gone.
+* you want changes in near real time rather than on a polling interval;
+* you do not want to add tracking properties to your data;
+* you need before-and-after state for updates.
+
+Consider the other source strategy if:
+
+xref:source/query.adoc[Query]:: You only want a specific slice of the graph, you are on Community
+Edition, or you cannot enable CDC. See xref:quickstart/source-query.adoc[Quickstart: Source with
+Query].
+
+[NOTE]
+====
+Sending these events into **another Neo4j database** is a separate exercise, because the sink side
+needs its own configuration and a second database.
+See xref:quickstart/sink-cdc.adoc[Quickstart: Sink with Change Data Capture] for that.
+This page stops at Kafka, where any consumer can read the events.
+====
+
+== What you will build
+
+One source connector, publishing changes to three topics split by operation:
+
+[source,text]
+----
+                          ┌──> creates topic
+(:Person) changes ──CDC──>├──> updates topic
+                          └──> deletes topic
+----
+
+Routing by operation is a configuration choice, not a requirement — one topic for everything is
+equally valid. Splitting them makes the event shapes easier to compare.
+
+== Prerequisites
+
+* Docker Compose v2.20.3 or later.
+* The {product-name} archive, unpacked as described in xref:installation.adoc[].
+* **Neo4j Enterprise Edition or Aura Enterprise.** CDC is not available in Community Edition.
+
+=== Start the environment
+
+Copy the following Docker Compose file into a new directory.
+
+.docker-compose.yml
+[source,yaml]
+----
+include::example$docker-data/docker-compose.yml[]
+----
+
+Copy the {product-name} JAR into a directory named `plugins` next to your `docker-compose.yml`:
+
+[source,text,subs="attributes+"]
+----
+quickstart/
+├─ plugins/
+│  ├─ neo4j-kafka-connect-{exact-connector-version}.jar
+├─ docker-compose.yml
+----
+
+[source,bash]
+----
+docker compose up -d
+docker compose ps
+----
+
+Wait until every service reports healthy — 90-120 seconds on a first run.
+
+[NOTE]
+====
+The source connector **always** produces messages with schemas, so a schemaless converter will not
+work.
+This guide uses `JsonConverter` with `schemas.enable=true`, which embeds the schema in each message
+and needs no Schema Registry.
+See <<other-formats>> for Avro and Protobuf.
+====
+
+== Step 1: Enable CDC
+
+Against the `system` database:
+
+[source,cypher]
+----
+ALTER DATABASE neo4j SET OPTION txLogEnrichment 'FULL';
+----
+
+Confirm it took effect:
+
+[source,cypher]
+----
+SHOW DATABASES YIELD name, options WHERE name = 'neo4j' RETURN name, options
+----
+
+For background, see
+link:{page-canonical-root}/cdc/current/get-started/self-managed[Change Data Capture > Enable CDC >
+Neo4j DBMS] for on-prem installations and
+link:{page-canonical-root}/cdc/current/get-started/aura[Change Data Capture > Enable CDC > Aura]
+for Aura.
+
+[NOTE]
+On Aura, CDC resets to `OFF` whenever an instance is paused and resumed.
+Re-enable it and follow xref:source/best-practices.adoc#source-cdc-cursor-recovery[CDC cursor
+recovery] before restarting the connector.
+
+== Step 2: Add a key constraint
+
+[source,cypher]
+----
+CREATE CONSTRAINT person_name IF NOT EXISTS
+FOR (p:Person) REQUIRE (p.first_name, p.last_name) IS NODE KEY;
+----
+
+This is optional for publishing, but it changes what the events contain: the constraint's properties
+are what populate each event's `keys` field, which is how a consumer identifies the entity without
+relying on Neo4j's internal ids.
+Any consumer doing upserts will want it.
+
+== Step 3: Create the topics
+
+[source,bash]
+----
+docker compose exec broker kafka-topics --bootstrap-server broker:29092 --create --topic creates --partitions 1 --replication-factor 1
+docker compose exec broker kafka-topics --bootstrap-server broker:29092 --create --topic updates --partitions 1 --replication-factor 1
+docker compose exec broker kafka-topics --bootstrap-server broker:29092 --create --topic deletes --partitions 1 --replication-factor 1
+----
+
+== Step 4: Create the source connector
+
+Save the following as `source.cdc.neo4j.json`:
+
+ifdef::backend-pdf[]
+.quickstart.source.cdc.operations.json-embedded.json
+endif::[]
+[source,json]
+----
+include::example$docker-data/quickstart.source.cdc.operations.json-embedded.json[]
+----
+
+Three settings deserve attention:
+
+`neo4j.cdc.topic.<topic>.patterns.N.pattern`:: What to capture, in Cypher-like pattern syntax.
+`(:Person)` means all changes to nodes with that label. The `N` is a 0-based index, so one topic can
+watch several patterns.
+`neo4j.cdc.topic.<topic>.patterns.N.operation`:: Narrows the pattern to `CREATE`, `UPDATE` or
+`DELETE`. Omit it to receive all three.
+`neo4j.start-from`:: `NOW` captures only changes made after the connector starts. `EARLIEST` starts
+from the beginning of the available change log, and `USER_PROVIDED` takes an explicit offset in
+`neo4j.start-from.value`. It applies only on first run — once an offset is stored in Kafka Connect,
+it is ignored.
+
+Register it:
+
+[source,bash]
+----
+curl -X POST http://localhost:8083/connectors \
+  -H 'Content-Type:application/json' \
+  -H 'Accept:application/json' \
+  -d @source.cdc.neo4j.json
+----
+
+[source,bash]
+----
+curl -s http://localhost:8083/connectors/Neo4jSourceCdcOperationsQuickstart/status
+----
+
+Both the connector and its task must report `RUNNING` before the next step — with
+`neo4j.start-from: NOW`, anything written earlier is never captured.
+
+[NOTE]
+A source connector always runs a single task, so `tasks.max` above `1` has no effect.
+
+== Step 5: Make some changes
+
+Against the `neo4j` database:
+
+[source,cypher]
+----
+CREATE (:Person {first_name: 'John', last_name: 'Doe', email: 'john.doe@example.com'});
+CREATE (:Person {first_name: 'Mary', last_name: 'Doe', email: 'mary.doe@example.com'});
+----
+
+[source,cypher]
+----
+MATCH (p:Person {first_name: 'John'}) SET p.email = 'john.doe@neo4j.com';
+----
+
+[source,cypher]
+----
+MATCH (p:Person {first_name: 'Mary'}) DELETE p;
+----
+
+== Step 6: Read the events
+
+Each topic should now hold exactly one kind of event:
+
+[source,bash]
+----
+docker compose exec broker kafka-console-consumer --bootstrap-server broker:29092 --topic creates --from-beginning --max-messages 2 --timeout-ms 15000
+----
+
+[source,bash]
+----
+docker compose exec broker kafka-console-consumer --bootstrap-server broker:29092 --topic updates --from-beginning --max-messages 1 --timeout-ms 15000
+----
+
+[source,bash]
+----
+docker compose exec broker kafka-console-consumer --bootstrap-server broker:29092 --topic deletes --from-beginning --max-messages 1 --timeout-ms 15000
+----
+
+With `schemas.enable=true` each message is a `{"schema": ..., "payload": ...}` envelope.
+The interesting half is the payload, whose shape is the
+link:{page-canonical-root}/cdc/current/procedures/output-schema/[CDC change event schema]:
+
+[source,json]
+----
+include::example$producer-data/node.created.cdc.json[]
+----
+
+The fields worth knowing:
+
+`event.operation`:: `c`, `u` or `d`.
+`event.eventType`:: `n` for a node, `r` for a relationship.
+`event.keys`:: the key properties, per label, taken from the constraint you created in Step 2.
+`event.state.before` / `event.state.after`:: the entity before and after the change. `before` is
+null for creates, `after` is null for deletes — which is what lets a consumer handle deletes at all.
+`txId` and `seq`:: transaction id and sequence within it, giving a total ordering.
+
+Each message also carries a `neo4j.source.cdc.id` Kafka **header**. The sink connector's CDC
+strategy uses that header to recognise change events, which is why hand-written messages cannot
+drive it.
+
+== Capturing relationships
+
+The pattern syntax covers relationships too. Add another pattern to any topic:
+
+[source,json]
+----
+  "neo4j.cdc.topic.creates.patterns.1.pattern": "(:Person)-[:KNOWS]->(:Person)",
+  "neo4j.cdc.topic.creates.patterns.1.operation": "CREATE"
+----
+
+Relationship events use `eventType: "r"` and carry `start` and `end` objects with the endpoint keys,
+rather than a `labels` field.
+
+Patterns can also filter on changed properties and transaction metadata — see
+xref:source/cdc.adoc[Change Data Capture strategy] for the full syntax.
+
+== Choosing what goes in the message key
+
+By default the whole change event is used as the message key, which is rarely what you want.
+`neo4j.cdc.topic.<topic>.key-strategy` accepts:
+
+[cols="1,3",opts=header]
+|===
+| Value | Key becomes
+
+| `WHOLE_VALUE` | the entire change event. The default.
+| `ENTITY_KEYS` | the key properties from the event — usually the right choice for partitioning and log compaction.
+| `ELEMENT_ID` | the source database's internal element id.
+| `SKIP` | no key at all.
+|===
+
+`ENTITY_KEYS` is what you want if consumers need all changes to one entity on the same partition.
+See xref:source/best-practices.adoc#cdc-key-strategy[Best practices] for the trade-offs.
+
+[[other-formats]]
+== Using Avro or Protobuf
+
+The source connector always emits schemas, so the only question is which schema format.
+To use the Schema Registry included in the Compose stack:
+
+[source,json]
+----
+  "key.converter": "io.confluent.connect.avro.AvroConverter",
+  "key.converter.schema.registry.url": "http://schema-registry:8081",
+  "value.converter": "io.confluent.connect.avro.AvroConverter",
+  "value.converter.schema.registry.url": "http://schema-registry:8081"
+----
+
+Reading those topics then needs a schema-aware consumer such as `kafka-avro-console-consumer`.
+Avro and Protobuf also represent temporal and numeric types more precisely than embedded-schema
+JSON. See xref:source/schema-registry.adoc[Schema Registry] and
+xref:source/payload-mode.adoc[Payload Mode], which controls how property values are represented.
+
+== Troubleshooting
+
+[source,bash]
+----
+curl -s http://localhost:8083/connectors/Neo4jSourceCdcOperationsQuickstart/status
+docker compose logs connect
+----
+
+Topics stay empty:: Most often CDC is not enabled, or the changes predate the connector. Check
+`SHOW DATABASES YIELD name, options` for `txLogEnrichment: FULL`, and remember that
+`neo4j.start-from: NOW` ignores everything written before startup.
+Task fails on startup with a pattern error:: Patterns are validated when the connector starts.
+Indexes must begin at `0` and be contiguous, and you cannot mix
+`patterns.N.pattern` with the single-string `patterns` form for the same topic.
+Events appear in the wrong topic:: Each topic's patterns are independent. A pattern with no
+`operation` receives creates, updates and deletes.
+`keys` is empty in every event:: No constraint on the captured label. Add one as in Step 2.
+Connector runs but lags behind:: Raise `neo4j.batch-size`, or shorten `neo4j.cdc.poll-interval`.
+See xref:source/best-practices.adoc[Best practices].
+Everything replays after a restart:: Kafka Connect stores the CDC cursor as a source offset. If it
+is lost, `neo4j.start-from` applies again.
+
+== Next steps
+
+* xref:source/cdc.adoc[Source CDC strategy] — full pattern syntax, operations, metadata filters.
+* xref:quickstart/sink-cdc.adoc[Quickstart: Sink with CDC] — apply these events to another Neo4j database.
+* xref:source/best-practices.adoc[Best practices] — cursor recovery, sizing, key strategies.
+* xref:source/payload-mode.adoc[Payload Mode] — how property values are serialized.
+* xref:source/monitoring.adoc[Monitoring] — JMX metrics exposed by the source connector.

--- a/modules/ROOT/pages/quickstart/source-query.adoc
+++ b/modules/ROOT/pages/quickstart/source-query.adoc
@@ -52,29 +52,7 @@ Community Edition is fine — this strategy needs neither CDC nor Enterprise fea
 
 === Start the environment
 
-Copy the following Docker Compose file into a new directory.
-
-.docker-compose.yml
-[source,yaml]
-----
-include::example$docker-data/docker-compose.yml[]
-----
-
-Copy the {product-name} JAR into a directory named `plugins` next to your `docker-compose.yml`:
-
-[source,text,subs="attributes+"]
-----
-quickstart/
-├─ plugins/
-│  ├─ neo4j-kafka-connect-{exact-connector-version}.jar
-├─ docker-compose.yml
-----
-
-[source,bash]
-----
-docker compose up -d
-docker compose ps
-----
+include::partial$quickstart-environment.adoc[]
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/quickstart/source-query.adoc
+++ b/modules/ROOT/pages/quickstart/source-query.adoc
@@ -21,11 +21,6 @@ Pick it when:
 * you want to shape the message in the query — aggregate, join, rename, filter;
 * your data already has a monotonically increasing tracking property.
 
-Consider the other source strategy if:
-
-xref:source/cdc.adoc[Change Data Capture]:: You need deletes, or you cannot add a tracking property
-to your model. See xref:quickstart/source-cdc.adoc[Quickstart: Source with Change Data Capture].
-
 [IMPORTANT]
 ====
 **This strategy cannot detect deletes.** A query only returns rows that exist, so a deleted node

--- a/modules/ROOT/pages/quickstart/source-query.adoc
+++ b/modules/ROOT/pages/quickstart/source-query.adoc
@@ -1,0 +1,272 @@
+= Quickstart: Source with Query
+:xrefstyle: full
+
+ifdef::env-docs[]
+[abstract]
+--
+Publish the results of your own Cypher query to Kafka on a polling interval.
+--
+endif::env-docs[]
+
+== When to use the Query strategy
+
+Use the xref:source/query.adoc[Query strategy] when you want to publish a **specific slice** of the
+graph and you can express "what changed since last time" as a Cypher query.
+The connector runs your query on an interval, passing in a cursor as `$lastCheck`.
+
+Pick it when:
+
+* you are on **Community Edition**, or cannot enable Change Data Capture;
+* you only want a narrow projection, not every change to the data;
+* you want to shape the message in the query — aggregate, join, rename, filter;
+* your data already has a monotonically increasing tracking property.
+
+Consider the other source strategy if:
+
+xref:source/cdc.adoc[Change Data Capture]:: You need deletes, or you cannot add a tracking property
+to your model. See xref:quickstart/source-cdc.adoc[Quickstart: Source with Change Data Capture].
+
+[IMPORTANT]
+====
+**This strategy cannot detect deletes.** A query only returns rows that exist, so a deleted node
+simply stops appearing — there is no event for it.
+If you need deletes, either use CDC or adopt soft deletes: keep the node, set a `deleted` flag, and
+bump the tracking property so the query picks up the change.
+====
+
+== What you will build
+
+One source connector polling a query and publishing each returned row to a topic:
+
+[source,text]
+----
+(:Reading) nodes ──every 1s──> MATCH ... WHERE r.timestamp > $lastCheck ──> readings topic
+----
+
+== Prerequisites
+
+* Docker Compose v2.20.3 or later.
+* The {product-name} archive, unpacked as described in xref:installation.adoc[].
+
+Community Edition is fine — this strategy needs neither CDC nor Enterprise features.
+
+=== Start the environment
+
+Copy the following Docker Compose file into a new directory.
+
+.docker-compose.yml
+[source,yaml]
+----
+include::example$docker-data/docker-compose.yml[]
+----
+
+Copy the {product-name} JAR into a directory named `plugins` next to your `docker-compose.yml`:
+
+[source,text,subs="attributes+"]
+----
+quickstart/
+├─ plugins/
+│  ├─ neo4j-kafka-connect-{exact-connector-version}.jar
+├─ docker-compose.yml
+----
+
+[source,bash]
+----
+docker compose up -d
+docker compose ps
+----
+
+[NOTE]
+====
+The source connector **always** produces messages with schemas, so a schemaless converter will not
+work.
+This guide uses `JsonConverter` with `schemas.enable=true`, which embeds the schema in each message
+and needs no Schema Registry.
+====
+
+== Step 1: Index the tracking property
+
+[source,cypher]
+----
+CREATE INDEX reading_timestamp IF NOT EXISTS FOR (r:Reading) ON (r.timestamp);
+----
+
+The connector filters on this property every poll.
+Without an index that is a full label scan on each cycle, which gets slower as the data grows.
+
+== Step 2: Create the topic
+
+[source,bash]
+----
+docker compose exec broker kafka-topics --bootstrap-server broker:29092 --create --topic readings --partitions 1 --replication-factor 1
+----
+
+== Step 3: Create the source connector
+
+Save the following as `source.query.neo4j.json`:
+
+ifdef::backend-pdf[]
+.quickstart.source.query.json-embedded.json
+endif::[]
+[source,json]
+----
+include::example$docker-data/quickstart.source.query.json-embedded.json[]
+----
+
+[source,bash]
+----
+curl -X POST http://localhost:8083/connectors \
+  -H 'Content-Type:application/json' \
+  -H 'Accept:application/json' \
+  -d @source.query.neo4j.json
+----
+
+[source,bash]
+----
+curl -s http://localhost:8083/connectors/Neo4jSourceQueryQuickstart/status
+----
+
+=== How the query works
+
+[source,cypher]
+----
+MATCH (r:Reading)
+WHERE r.timestamp > $lastCheck
+RETURN r.sensor AS sensor, r.celsius AS celsius, r.timestamp AS timestamp
+ORDER BY r.timestamp
+----
+
+`$lastCheck`:: Supplied by the connector on every poll. It starts from `neo4j.start-from` and then
+advances to the tracking property of the **last row** of each batch.
+`neo4j.query.streaming-property`:: Names the returned field used as the cursor — `timestamp` here.
+It must be part of the `RETURN`, or the connector cannot advance.
+`ORDER BY`:: Not optional in practice. The connector takes the cursor from the last row it received,
+so if rows come back unordered it can jump past values it never published.
+
+[IMPORTANT]
+====
+**The tracking property must be an integer**, not a `datetime`.
+The cursor is handled internally as a long — `neo4j.start-from: NOW` seeds it with
+`System.currentTimeMillis()` — so the property should hold epoch milliseconds, which is what
+Cypher's `timestamp()` returns.
+Returning a `DATETIME` instead fails with
+`Returned record does not contain a valid field timestamp ... expected a long value`.
+====
+
+Note also that the comparison is `>`, strictly greater than.
+Two rows sharing a timestamp value can mean the second is never published, so a tracking property
+with sufficient resolution matters. Milliseconds is usually enough; seconds often is not.
+
+=== Where polling starts
+
+`neo4j.start-from` is `EARLIEST` in this configuration, which seeds the cursor with `-1` so
+**existing** rows are published on the first poll. That makes the walkthrough below easy to follow.
+
+For a real deployment `NOW` is usually what you want — it seeds the cursor with the current
+timestamp, so only new rows are published. `USER_PROVIDED` takes an explicit value in
+`neo4j.start-from.value`.
+All three apply only on first run; once Kafka Connect has stored an offset, the setting is ignored
+unless you set `neo4j.ignore-stored-offset`.
+
+== Step 4: Insert some data
+
+[source,cypher]
+----
+CREATE (:Reading {sensor: 'kitchen', celsius: 21.5, timestamp: timestamp()});
+CREATE (:Reading {sensor: 'garage', celsius: 8.0, timestamp: timestamp()});
+----
+
+`timestamp()` returns the current time in epoch milliseconds as an integer, which is exactly what
+the cursor expects.
+
+== Step 5: Read the messages
+
+[source,bash]
+----
+docker compose exec broker kafka-console-consumer --bootstrap-server broker:29092 --topic readings --from-beginning --max-messages 2 --timeout-ms 15000
+----
+
+Each message is a `{"schema": ..., "payload": ...}` envelope, and each `payload` is one row of your
+query — the aliases in the `RETURN` become the field names:
+
+[source,json]
+----
+{"sensor": "kitchen", "celsius": 21.5, "timestamp": 1730000000000}
+----
+
+Now add another row and watch it arrive within a poll interval:
+
+[source,cypher]
+----
+CREATE (:Reading {sensor: 'attic', celsius: 15.25, timestamp: timestamp()});
+----
+
+[source,bash]
+----
+docker compose exec broker kafka-console-consumer --bootstrap-server broker:29092 --topic readings --from-beginning --max-messages 3 --timeout-ms 15000
+----
+
+Then confirm the cursor is doing its job — update an existing row **without** touching its
+timestamp:
+
+[source,cypher]
+----
+MATCH (r:Reading {sensor: 'kitchen'}) SET r.celsius = 30.0;
+----
+
+Nothing new is published. The query only sees rows whose `timestamp` exceeds the cursor, so a change
+that does not bump the tracking property is invisible.
+Bump it and the row is published again:
+
+[source,cypher]
+----
+MATCH (r:Reading {sensor: 'kitchen'}) SET r.celsius = 30.0, r.timestamp = timestamp();
+----
+
+That is the discipline this strategy requires: **every write that should be published must advance
+the tracking property.** It is the main reason to prefer CDC when it is available.
+
+== Message shape and types
+
+xref:source/payload-mode.adoc[Payload Mode] controls how values are represented:
+
+[cols="1,3",opts=header]
+|===
+| `neo4j.payload-mode` | Effect
+
+| `EXTENDED` | Default. Rich type information preserved, at the cost of a more nested message.
+| `COMPACT` | Simpler messages, some type fidelity lost.
+| `RAW_JSON_STRING` | The whole payload as a single JSON string, for consumers that parse it themselves.
+|===
+
+Returning whole nodes rather than properties also works — `RETURN r` — but the message then carries
+Neo4j-specific structure. Projecting explicit fields, as above, keeps consumers independent of your
+graph model.
+
+== Troubleshooting
+
+[source,bash]
+----
+curl -s http://localhost:8083/connectors/Neo4jSourceQueryQuickstart/status
+docker compose logs connect
+----
+
+`Returned record does not contain a valid field <prop> ... expected a long value`:: The tracking
+property is not an integer, or is missing from the `RETURN`. Use `timestamp()`, not `datetime()`.
+Topic stays empty:: With `neo4j.start-from: NOW` only rows created after startup qualify. Check
+whether your rows predate the connector, and that their `timestamp` really exceeds the cursor.
+Rows published repeatedly:: The query returns rows whose tracking property does not advance past the
+cursor. Confirm the `WHERE` uses `$lastCheck` and that `neo4j.query.streaming-property` names a
+returned field.
+Some rows never appear:: Either two rows share a tracking value — the comparison is strictly `>` —
+or the query has no `ORDER BY` on the tracking property, so the cursor skipped ahead.
+Deletes not appearing:: Expected. This strategy cannot see deletes; use soft deletes or CDC.
+Polling gets slower over time:: The tracking property is not indexed. See Step 1.
+
+== Next steps
+
+* xref:source/query.adoc[Source Query strategy] — full reference.
+* xref:quickstart/source-cdc.adoc[Quickstart: Source with CDC] — the alternative, when you need deletes.
+* xref:source/payload-mode.adoc[Payload Mode] — message representation.
+* xref:source/configuration.adoc[Source settings] — batching, polling, offsets.
+* xref:source/monitoring.adoc[Monitoring] — JMX metrics exposed by the source connector.

--- a/modules/ROOT/partials/quickstart-environment.adoc
+++ b/modules/ROOT/partials/quickstart-environment.adoc
@@ -1,0 +1,46 @@
+Copy the following Docker Compose file into a new directory.
+
+.docker-compose.yml
+[source,yaml]
+----
+include::example$docker-data/docker-compose.yml[]
+----
+
+Copy the {product-name} JAR into a directory named `plugins` next to your `docker-compose.yml`,
+so that the directory looks like this:
+
+[source,text,subs="attributes+"]
+----
+quickstart/
+├─ plugins/
+│  ├─ neo4j-kafka-connect-{exact-connector-version}.jar
+├─ docker-compose.yml
+----
+
+Start the stack:
+
+[source,bash]
+----
+docker compose up -d
+----
+
+Wait until every service reports as healthy — this takes 90-120 seconds on a first run:
+
+[source,bash]
+----
+docker compose ps
+----
+
+Confirm that the connector plugin was loaded:
+
+[source,bash]
+----
+curl -s http://localhost:8083/connector-plugins | grep -o 'org.neo4j.connectors.kafka.[a-z]*.Neo4jConnector'
+----
+
+Both `...source.Neo4jConnector` and `...sink.Neo4jConnector` should be listed.
+Empty output means the JAR is missing from `plugins` or failed to load — check
+`docker compose logs connect`.
+
+You can now log in to Neo4j Browser at \http://localhost:7474 with the username `neo4j` and the
+password `password`.


### PR DESCRIPTION
  **New pages** (7 files under `pages/quickstart/`):                                                                                                                                                                               
                                                                                                                                                                                                                                   
  - `index.adoc` — a table that helps you pick the right strategy                                                                                                                                                                  
  - `sink-cypher.adoc`, `sink-pattern.adoc`, `sink-cud.adoc`, `sink-cdc.adoc`                                                                                                                                                      
  - `source-cdc.adoc`, `source-query.adoc`                                                                                                                                                                                         
                                                                                                                                                                                                                                   
  Every page has the same structure: when to use this strategy, what to use instead,                                                                                                                                               
  set up the environment, create the connector, send messages, check the result, and                                                                                                                                               
  fix common problems. Each one runs end to end on a local Docker stack.                                                                                                                                                           
                                                                         
 - Fixed a typo in three `quickstart.sink.cdc-schema.*` examples:                                                                                                                                                                 
    `updates.deletes` should be `updates,deletes`                                                                                                                                                                                  
  - Updated `content-nav.adoc`    